### PR TITLE
feat(linter): print git diff for debug info on fail

### DIFF
--- a/linter/orb.yaml
+++ b/linter/orb.yaml
@@ -28,6 +28,10 @@ commands:
           paths:
             - ~/.cache/pre-commit
       - run: pre-commit run --all-files -c <<parameters.config_file>>
+      - run:
+          name: git diff
+          command: git diff
+          when: on_fail
 
 jobs:
   pre-commit:


### PR DESCRIPTION
In cases where `pre-commit` runs and makes changes, running this
afterwards will help our failing tests to have a bit more debugging
output.