### PR TITLE
feat: allow resource_class configuration

### DIFF
--- a/deployer/orb.yaml
+++ b/deployer/orb.yaml
@@ -53,6 +53,7 @@ jobs:
       OSS projects!
     docker:
       - image: python:<<parameters.python_version>>
+    resource_class: <<parameters.resource_class>>
     parameters:
       folder:
         default: '.'
@@ -68,6 +69,9 @@ jobs:
         description: >
           Python version to use to build and deploy the package. Used as the
           docker executor, so you can use any sort of tag (eg. ``3.7.4-slim``).
+        type: string
+      resource_class:
+        default: small
         type: string
       verify_version:
         default: ${CIRCLE_TAG}

--- a/docker/orb.yaml
+++ b/docker/orb.yaml
@@ -367,6 +367,7 @@ jobs:
       this is a tag build), and "latest".
     docker:
       - image: <<parameters.executor>>
+    resource_class: <<parameters.resource_class>>
     parameters:
       build_args:
         default: ''
@@ -400,6 +401,9 @@ jobs:
         default: 'docker.io'
         description: >
           Container registry to-be-used.
+        type: string
+      resource_class:
+        default: medium
         type: string
       workspace:
         default: ''

--- a/docs/orb.yaml
+++ b/docs/orb.yaml
@@ -9,6 +9,7 @@ jobs:
       APIdocs, etc.
     docker:
       - image: <<parameters.executor>>
+    resource_class: <<parameters.resource_class>>
     parameters:
       creds:
         default: GCLOUD_SERVICE_KEY
@@ -76,6 +77,9 @@ jobs:
         default: ${CIRCLE_PROJECT_REPONAME}
         description: |
           The name of the project folder in GCS.
+        type: string
+      resource_class:
+        default: small
         type: string
     steps:
       - run: python3 -m pip install sphinx

--- a/gcloud/orb.yaml
+++ b/gcloud/orb.yaml
@@ -77,6 +77,7 @@ jobs:
       Deploy a package to Google's Cloud Function service.
     docker:
       - image: google/cloud-sdk:alpine
+    resource_class: <<parameters.resource_class>>
     parameters:
       creds:
         default: GCLOUD_SERVICE_KEY
@@ -95,6 +96,9 @@ jobs:
       project:
         description: >
           Name of GCP project to which we will push.
+        type: string
+      resource_class:
+        default: small
         type: string
     steps:
       - auth:
@@ -121,6 +125,7 @@ jobs:
       specified Knative cluster.
     docker:
       - image: google/cloud-sdk:alpine
+    resource_class: <<parameters.resource_class>>
     parameters:
       creds:
         default: GCLOUD_SERVICE_KEY
@@ -176,6 +181,9 @@ jobs:
         description: >
           Name of GCP region to which we will push.
         type: string
+      resource_class:
+        default: small
+        type: string
     steps:
       - auth:
           creds: <<parameters.creds>>
@@ -229,6 +237,7 @@ jobs:
       ``./bin/interpolate-k8s`` to build a ``k8s.yaml`` file otherwise.
     docker:
       - image: google/cloud-sdk:alpine
+    resource_class: <<parameters.resource_class>>
     parameters:
       creds:
         default: GCLOUD_SERVICE_KEY
@@ -270,6 +279,9 @@ jobs:
         default: 'gcr.io'
         description: >
           Container registry to-be-used.
+        type: string
+      resource_class:
+        default: small
         type: string
       tag:
         default: ${CIRCLE_SHA1:0:10}
@@ -319,6 +331,7 @@ jobs:
       build), tag (if this is a tag build), and "latest".
     docker:
       - image: <<parameters.executor>>
+    resource_class: <<parameters.resource_class>>
     parameters:
       build_args:
         default: ''
@@ -362,6 +375,9 @@ jobs:
         default: 'gcr.io'
         description: >
           Container registry to-be-used.
+        type: string
+      resource_class:
+        default: medium
         type: string
       workspace:
         default: ''

--- a/linter/orb.yaml
+++ b/linter/orb.yaml
@@ -35,6 +35,7 @@ jobs:
       Runs pre-commit hooks against the current repo.
     docker:
       - image: python:<<parameters.python_version>>
+    resource_class: <<parameters.resource_class>>
     parameters:
       config_file:
         default: '.pre-commit-config.yaml'
@@ -45,6 +46,9 @@ jobs:
         default: 3.7.2
         description: |
           The python version used to run pre-commit.
+        type: string
+      resource_class:
+        default: small
         type: string
     steps:
       - pre-commit:

--- a/tester/orb.yaml
+++ b/tester/orb.yaml
@@ -7,6 +7,7 @@ jobs:
       Runs pip check against the current repo.
     docker:
       - image: python:<<parameters.python_version>>
+    resource_class: <<parameters.resource_class>>
     parameters:
       cache_prefix:
         default: ''
@@ -33,6 +34,9 @@ jobs:
         default: 3.7.2
         description: |
           The python version used to run pytest.
+        type: string
+      resource_class:
+        default: small
         type: string
     steps:
       - checkout
@@ -67,6 +71,7 @@ jobs:
       Runs pytest against the current repo.
     docker:
       - image: python:<<parameters.python_version>>
+    resource_class: <<parameters.resource_class>>
     parameters:
       args:
         default: ''
@@ -98,6 +103,9 @@ jobs:
         default: 3.7.2
         description: |
           The python version used to run pytest.
+        type: string
+      resource_class:
+        default: small
         type: string
     steps:
       - checkout


### PR DESCRIPTION
The goal here is to make things more configurable, eg. so users can run
jobs on larger instances for heftier CI steps. Additionally, this sets
the default to `small` instead of `medium` (ie. the CircleCI default
when unspecified) for cases where a single CPU should generally be
enough.