### PR TITLE
feat(tester): add job for running docker-compose integration tests

### DIFF
--- a/tester/orb.yaml
+++ b/tester/orb.yaml
@@ -147,6 +147,11 @@ jobs:
         description: |
           Arguments to pass to downstream container
         type: string
+      build:
+        default: ''
+        description: |
+          Services to build besides target service
+        type: string
       cwd:
         default: '.'
         description: >
@@ -171,7 +176,7 @@ jobs:
       - run:
           working_directory: <<parameters.cwd>>
           # has to be built explicitly https://github.com/docker/compose/issues/7336
-          command: docker-compose build <<parameters.service_name>>
+          command: docker-compose build <<parameters.service_name>> <<parameters.build>>
           environment:
             DOCKER_BUILDKIT: 1
             COMPOSE_DOCKER_CLI_BUILD: 1

--- a/tester/orb.yaml
+++ b/tester/orb.yaml
@@ -134,3 +134,47 @@ jobs:
           command: |
             cd <<parameters.cwd>>
             python -m pytest <<parameters.args>>
+
+  integration-tests:
+    description:
+      Runs integration tests using docker-compose
+    docker:
+      - image: <<parameters.executor>>
+    resource_class: <<parameters.resource_class>>
+    parameters:
+      args:
+        default: ''
+        description: |
+          Arguments to pass to pytest
+        type: string
+      cwd:
+        default: '.'
+        description: >
+          Working directory used when running pip / pytest commands.
+        type: string
+      executor:
+        default: cimg/base:2020.01
+        description: >
+          Name of the docker image to use to execute the job.
+        type: string
+      resource_class:
+        default: small
+        type: string
+      service_name:
+        default: integration-tests
+        description: >
+          Name of docker-compose service containing integration tests
+        type: string
+    steps:
+      - setup_remote_docker:
+          version: 18.09.3
+      - checkout
+      - run:
+          working_directory: <<parameters.cwd>>
+          # has to be built explicitely https://github.com/docker/compose/issues/7336
+          command: |
+            docker-compose build <<parameters.service_name>>
+            docker-compose run --rm <<parameters.service_name>> <<parameters.args>>
+          environment:
+            DOCKER_BUILDKIT: 1
+            COMPOSE_DOCKER_CLI_BUILD: 1

--- a/tester/orb.yaml
+++ b/tester/orb.yaml
@@ -145,12 +145,12 @@ jobs:
       args:
         default: ''
         description: |
-          Arguments to pass to pytest
+          Arguments to pass to downstream container
         type: string
       cwd:
         default: '.'
         description: >
-          Working directory used when running pip / pytest commands.
+          Working directory used when running docker-compose commands.
         type: string
       executor:
         default: cimg/base:2020.01
@@ -171,7 +171,7 @@ jobs:
       - checkout
       - run:
           working_directory: <<parameters.cwd>>
-          # has to be built explicitely https://github.com/docker/compose/issues/7336
+          # has to be built explicitly https://github.com/docker/compose/issues/7336
           command: |
             docker-compose build <<parameters.service_name>>
             docker-compose run --rm <<parameters.service_name>> <<parameters.args>>

--- a/tester/orb.yaml
+++ b/tester/orb.yaml
@@ -135,9 +135,9 @@ jobs:
             cd <<parameters.cwd>>
             python -m pytest <<parameters.args>>
 
-  integration-tests:
+  docker-compose:
     description:
-      Runs integration tests using docker-compose
+      Runs docker-compose service
     docker:
       - image: <<parameters.executor>>
     resource_class: <<parameters.resource_class>>
@@ -161,9 +161,8 @@ jobs:
         default: small
         type: string
       service_name:
-        default: integration-tests
         description: >
-          Name of docker-compose service containing integration tests
+          Name of docker-compose service to run
         type: string
     steps:
       - setup_remote_docker:
@@ -172,9 +171,10 @@ jobs:
       - run:
           working_directory: <<parameters.cwd>>
           # has to be built explicitly https://github.com/docker/compose/issues/7336
-          command: |
-            docker-compose build <<parameters.service_name>>
-            docker-compose run --rm <<parameters.service_name>> <<parameters.args>>
+          command: docker-compose build <<parameters.service_name>>
           environment:
             DOCKER_BUILDKIT: 1
             COMPOSE_DOCKER_CLI_BUILD: 1
+      - run:
+          working_directory: <<parameters.cwd>>
+          command: docker-compose run --rm <<parameters.service_name>> <<parameters.args>>


### PR DESCRIPTION
Surprisingly for me, docker-compose works pretty seamlessly in circleci.

Green build: https://app.circleci.com/pipelines/github/talkiq/realtime/1883/workflows/a291ae1f-9dc3-4a6e-8cc6-bffad54e307c/jobs/9329