### PR TITLE
Improve Tester

### DIFF
--- a/tester/orb.yaml
+++ b/tester/orb.yaml
@@ -157,6 +157,11 @@ jobs:
         description: >
           Working directory used when running docker-compose commands.
         type: string
+      compose_args:
+        default: '-f docker-compose.yaml'
+        description: >
+          Docker-compose args such as a chain of files to use.
+        type: string
       executor:
         default: cimg/base:2020.01
         description: >
@@ -176,10 +181,11 @@ jobs:
       - run:
           working_directory: <<parameters.cwd>>
           # has to be built explicitly https://github.com/docker/compose/issues/7336
-          command: docker-compose build <<parameters.service_name>> <<parameters.build>>
+          command: docker-compose <<parameters.compose_args>> build <<parameters.service_name>> <<parameters.build>>
           environment:
             DOCKER_BUILDKIT: 1
             COMPOSE_DOCKER_CLI_BUILD: 1
       - run:
           working_directory: <<parameters.cwd>>
-          command: docker-compose run --rm <<parameters.service_name>> <<parameters.args>>
+          command: docker-compose <<parameters.compose_args>> run --rm <<parameters.service_name>> <<parameters.args>>
+

--- a/tester/orb.yaml
+++ b/tester/orb.yaml
@@ -188,4 +188,7 @@ jobs:
       - run:
           working_directory: <<parameters.cwd>>
           command: docker-compose <<parameters.compose_args>> run --rm <<parameters.service_name>> <<parameters.args>>
-
+      - run:
+          working_directory: <<parameters.cwd>>
+          command: docker-compose <<parameters.compose_args>> logs
+          when: on_fail


### PR DESCRIPTION
Two improvements here:
1. Let client decide which `docker-compose.yaml` files to run. This is needed so we could explicitly only run `-f docker-compose.yaml` and not touch `docker-compose.override.yaml`. 
`docker-compose.override.yaml` -> is a file read by default. Here we can put things that exist for local convenience (primarily volumes with code). https://github.com/talkiq/realtime/pull/408/files#diff-f411261c4abb5a1df0ec1827371502ebR1 This allows us to get rid of CI-specific `integration-tests` service!
2. Output logs if previous step failed