### PR TITLE
chore(tester) Sort docker-compose logs

### DIFF
--- a/tester/orb.yaml
+++ b/tester/orb.yaml
@@ -225,7 +225,7 @@ jobs:
             LD_LIBRARY_PATH: /usr/local/lib
       - run:
           working_directory: <<parameters.cwd>>
-          command: docker-compose <<parameters.compose_args>> logs
+          command: docker-compose <<parameters.compose_args>> logs -t | sort -u -k 3
           when: on_fail
 
 orbs:

--- a/tester/orb.yaml
+++ b/tester/orb.yaml
@@ -225,7 +225,7 @@ jobs:
             LD_LIBRARY_PATH: /usr/local/lib
       - run:
           working_directory: <<parameters.cwd>>
-          command: docker-compose <<parameters.compose_args>> logs -t | sort -u -k 3
+          command: docker-compose <<parameters.compose_args>> logs -t | sort -k 3
           when: on_fail
 
 orbs:


### PR DESCRIPTION
OK so by default `docker-compose logs` records sorted in the order they were received from containers which isn't really chronological. This PR uses [this workaround](https://github.com/docker/compose/issues/5398#issuecomment-654816131) to properly sort logs.