### PR TITLE
fix(docker): bump to non-deprecated versions

### DIFF
--- a/gcloud/orb.yaml
+++ b/gcloud/orb.yaml
@@ -43,13 +43,13 @@ commands:
           condition: <<parameters.docker_layer_caching>>
           steps:
             - setup_remote_docker:
-                version: 18.09.3
+                version: 19.03.12
                 docker_layer_caching: true
       - unless:
           condition: <<parameters.docker_layer_caching>>
           steps:
             - setup_remote_docker:
-                version: 18.09.3
+                version: 19.03.12
       - run: gcloud auth configure-docker --quiet
 
   configure-gke:
@@ -374,7 +374,7 @@ jobs:
           Name of dockerfile to use.
         type: string
       executor:
-        default: docker:18.09.3-git
+        default: docker:19.03.12-git
         description: >
           Name of the docker image to use to execute the job.
         type: string

--- a/tester/orb.yaml
+++ b/tester/orb.yaml
@@ -207,7 +207,7 @@ jobs:
             and: [<<parameters.gcr_creds>>, <<parameters.gcr_project>>]
           steps:
             - setup_remote_docker:
-                version: 18.09.3
+                version: 19.03.12
       - checkout
       - run:
           working_directory: <<parameters.cwd>>


### PR DESCRIPTION
## Summary
CircleCI is deprecating[1] these older versions in about a month.

1: https://discuss.circleci.com/t/old-linux-machine-image-remote-docker-deprecation/37572

### Checklist
- [ ] manual testing has passed