### PR TITLE
feat(poetry): create new poetry orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,436 +13,50 @@ workflows:
             tags:
               only: /.*/
 
-      # ORB: deployer
       - orb-tools/lint:
-          name: lint-orbs-deployer
-          lint-dir: deployer
+          name: lint-orbs-<<matrix.lint-dir>>
+          matrix:
+            parameters:
+              lint-dir: [deployer, docs, docker, gcloud, linter, notifier, poetry, tester]
           filters:
             tags:
               only: /.*/
-      - orb-tools/pack:
-          name: pack-orbs-deployer
-          source-dir: deployer
-          filters:
-            tags:
-              only: /.*/
-          requires:
-            - linter/pre-commit
-            - lint-orbs-deployer
-      - orb-tools/publish-dev:
-          context: org-global
-          name: publish-dev-orbs-deployer
-          orb-name: talkiq/deployer
-          filters:
-            tags:
-              only: /.*/
-          requires:
-            - pack-orbs-deployer
-      - orb-tools/dev-promote-prod:
-          context: org-global
-          name: dev-promote-prod-orbs-deployer
-          orb-name: talkiq/deployer
-          release: patch
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /deployer-patch/
-          requires:
-            - publish-dev-orbs-deployer
-      - orb-tools/dev-promote-prod:
-          context: org-global
-          name: dev-promote-prod-orbs-deployer
-          orb-name: talkiq/deployer
-          release: minor
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /deployer-minor/
-          requires:
-            - publish-dev-orbs-deployer
-      - orb-tools/dev-promote-prod:
-          context: org-global
-          name: dev-promote-prod-orbs-deployer
-          orb-name: talkiq/deployer
-          release: major
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /deployer-major/
-          requires:
-            - publish-dev-orbs-deployer
 
-      # ORB: docs
-      - orb-tools/lint:
-          name: lint-orbs-docs
-          lint-dir: docs
-          filters:
-            tags:
-              only: /.*/
       - orb-tools/pack:
-          name: pack-orbs-docs
-          source-dir: docs
+          name: pack-orbs-talkiq/<<matrix.source-dir>>
+          matrix:
+            parameters:
+              source-dir: [deployer, docs, docker, gcloud, linter, notifier, poetry, tester]
           filters:
             tags:
               only: /.*/
           requires:
             - linter/pre-commit
-            - lint-orbs-docs
-      - orb-tools/publish-dev:
-          context: org-global
-          name: publish-dev-orbs-docs
-          orb-name: talkiq/docs
-          filters:
-            tags:
-              only: /.*/
-          requires:
-            - pack-orbs-docs
-      - orb-tools/dev-promote-prod:
-          context: org-global
-          name: dev-promote-prod-orbs-docs
-          orb-name: talkiq/docs
-          release: patch
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /docs-patch/
-          requires:
-            - publish-dev-orbs-docs
-      - orb-tools/dev-promote-prod:
-          context: org-global
-          name: dev-promote-prod-orbs-docs
-          orb-name: talkiq/docs
-          release: minor
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /docs-minor/
-          requires:
-            - publish-dev-orbs-docs
-      - orb-tools/dev-promote-prod:
-          context: org-global
-          name: dev-promote-prod-orbs-docs
-          orb-name: talkiq/docs
-          release: major
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /docs-major/
-          requires:
-            - publish-dev-orbs-docs
+            - lint-orbs-<<matrix.source-dir>>
 
-      # ORB: docker
-      - orb-tools/lint:
-          name: lint-orbs-docker
-          lint-dir: docker
-          filters:
-            tags:
-              only: /.*/
-      - orb-tools/pack:
-          name: pack-orbs-docker
-          source-dir: docker
-          filters:
-            tags:
-              only: /.*/
-          requires:
-            - linter/pre-commit
-            - lint-orbs-docker
       - orb-tools/publish-dev:
           context: org-global
-          name: publish-dev-orbs-docker
-          orb-name: talkiq/docker
+          name: publish-dev-orbs-<<matrix.orb-name>>
+          matrix:
+            parameters:
+              orb-name: [talkiq/deployer, talkiq/docs, talkiq/docker, talkiq/gcloud, talkiq/linter, talkiq/notifier, talkiq/poetry, talkiq/tester]
           filters:
             tags:
               only: /.*/
           requires:
-            - pack-orbs-docker
-      - orb-tools/dev-promote-prod:
-          context: org-global
-          name: dev-promote-prod-orbs-docker
-          orb-name: talkiq/docker
-          release: patch
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /docker-patch/
-          requires:
-            - publish-dev-orbs-docker
-      - orb-tools/dev-promote-prod:
-          context: org-global
-          name: dev-promote-prod-orbs-docker
-          orb-name: talkiq/docker
-          release: minor
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /docker-minor/
-          requires:
-            - publish-dev-orbs-docker
-      - orb-tools/dev-promote-prod:
-          context: org-global
-          name: dev-promote-prod-orbs-docker
-          orb-name: talkiq/docker
-          release: major
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /docker-major/
-          requires:
-            - publish-dev-orbs-docker
+            - pack-orbs-<<matrix.orb-name>>
 
-      # ORB: gcloud
-      - orb-tools/lint:
-          name: lint-orbs-gcloud
-          lint-dir: gcloud
-          filters:
-            tags:
-              only: /.*/
-      - orb-tools/pack:
-          name: pack-orbs-gcloud
-          source-dir: gcloud
-          filters:
-            tags:
-              only: /.*/
-          requires:
-            - linter/pre-commit
-            - lint-orbs-gcloud
-      - orb-tools/publish-dev:
-          context: org-global
-          name: publish-dev-orbs-gcloud
-          orb-name: talkiq/gcloud
-          filters:
-            tags:
-              only: /.*/
-          requires:
-            - pack-orbs-gcloud
       - orb-tools/dev-promote-prod:
           context: org-global
-          name: dev-promote-prod-orbs-gcloud
-          orb-name: talkiq/gcloud
-          release: patch
+          name: dev-promote-prod-orbs-<<matrix.orb-name>>-<<matrix.release>>
+          matrix:
+            parameters:
+              orb-name: [talkiq/deployer, talkiq/docs, talkiq/docker, talkiq/gcloud, talkiq/linter, talkiq/notifier, talkiq/poetry, talkiq/tester]
+              release: [patch, minor, major]
           filters:
             branches:
               ignore: /.*/
             tags:
-              only: /gcloud-patch/
+              only: /<<matrix.orb-name>>-<<matrix.release>>/
           requires:
-            - publish-dev-orbs-gcloud
-      - orb-tools/dev-promote-prod:
-          context: org-global
-          name: dev-promote-prod-orbs-gcloud
-          orb-name: talkiq/gcloud
-          release: minor
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /gcloud-minor/
-          requires:
-            - publish-dev-orbs-gcloud
-      - orb-tools/dev-promote-prod:
-          context: org-global
-          name: dev-promote-prod-orbs-gcloud
-          orb-name: talkiq/gcloud
-          release: major
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /gcloud-major/
-          requires:
-            - publish-dev-orbs-gcloud
-
-      # ORB: linter
-      - orb-tools/lint:
-          name: lint-orbs-linter
-          lint-dir: linter
-          filters:
-            tags:
-              only: /.*/
-      - orb-tools/pack:
-          name: pack-orbs-linter
-          source-dir: linter
-          filters:
-            tags:
-              only: /.*/
-          requires:
-            - linter/pre-commit
-            - lint-orbs-linter
-      - orb-tools/publish-dev:
-          context: org-global
-          name: publish-dev-orbs-linter
-          orb-name: talkiq/linter
-          filters:
-            tags:
-              only: /.*/
-          requires:
-            - pack-orbs-linter
-      - orb-tools/dev-promote-prod:
-          context: org-global
-          name: dev-promote-prod-orbs-linter
-          orb-name: talkiq/linter
-          release: patch
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /linter-patch/
-          requires:
-            - publish-dev-orbs-linter
-      - orb-tools/dev-promote-prod:
-          context: org-global
-          name: dev-promote-prod-orbs-linter
-          orb-name: talkiq/linter
-          release: minor
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /linter-minor/
-          requires:
-            - publish-dev-orbs-linter
-      - orb-tools/dev-promote-prod:
-          context: org-global
-          name: dev-promote-prod-orbs-linter
-          orb-name: talkiq/linter
-          release: major
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /linter-major/
-          requires:
-            - publish-dev-orbs-linter
-
-      # ORB: notifier
-      - orb-tools/lint:
-          name: lint-orbs-notifier
-          lint-dir: notifier
-          filters:
-            tags:
-              only: /.*/
-      - orb-tools/pack:
-          name: pack-orbs-notifier
-          source-dir: notifier
-          filters:
-            tags:
-              only: /.*/
-          requires:
-            - linter/pre-commit
-            - lint-orbs-notifier
-      - orb-tools/publish-dev:
-          context: org-global
-          name: publish-dev-orbs-notifier
-          orb-name: talkiq/notifier
-          filters:
-            tags:
-              only: /.*/
-          requires:
-            - pack-orbs-notifier
-      - orb-tools/dev-promote-prod:
-          context: org-global
-          name: dev-promote-prod-orbs-notifier
-          orb-name: talkiq/notifier
-          release: patch
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /notifier-patch/
-          requires:
-            - publish-dev-orbs-notifier
-      - orb-tools/dev-promote-prod:
-          context: org-global
-          name: dev-promote-prod-orbs-notifier
-          orb-name: talkiq/notifier
-          release: minor
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /notifier-minor/
-          requires:
-            - publish-dev-orbs-notifier
-      - orb-tools/dev-promote-prod:
-          context: org-global
-          name: dev-promote-prod-orbs-notifier
-          orb-name: talkiq/notifier
-          release: major
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /notifier-major/
-          requires:
-            - publish-dev-orbs-notifier
-
-      # ORB: tester
-      - orb-tools/lint:
-          name: lint-orbs-tester
-          lint-dir: tester
-          filters:
-            tags:
-              only: /.*/
-      - orb-tools/pack:
-          name: pack-orbs-tester
-          source-dir: tester
-          filters:
-            tags:
-              only: /.*/
-          requires:
-            - linter/pre-commit
-            - lint-orbs-tester
-      - orb-tools/publish-dev:
-          context: org-global
-          name: publish-dev-orbs-tester
-          orb-name: talkiq/tester
-          filters:
-            tags:
-              only: /.*/
-          requires:
-            - pack-orbs-tester
-      - orb-tools/dev-promote-prod:
-          context: org-global
-          name: dev-promote-prod-orbs-tester
-          orb-name: talkiq/tester
-          release: patch
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /tester-patch/
-          requires:
-            - publish-dev-orbs-tester
-      - orb-tools/dev-promote-prod:
-          context: org-global
-          name: dev-promote-prod-orbs-tester
-          orb-name: talkiq/tester
-          release: minor
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /tester-minor/
-          requires:
-            - publish-dev-orbs-tester
-      - orb-tools/dev-promote-prod:
-          context: org-global
-          name: dev-promote-prod-orbs-tester
-          orb-name: talkiq/tester
-          release: major
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /tester-major/
-          requires:
-            - publish-dev-orbs-tester
+            - publish-dev-orbs-<<matrix.orb-name>>

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ implementation-specific to be worthwhile outside of the company.
 Usage
 -----
 
-|deployer| |docker| |docs| |gcloud| |linter| |notifier| |tester|
+|deployer| |docker| |docs| |gcloud| |linter| |notifier| |poetry| |tester|
 
 Simply include the ``orb`` or ``orbs`` you're interested in within your
 ``.circleci/config.yml`` file:
@@ -24,6 +24,7 @@ Simply include the ``orb`` or ``orbs`` you're interested in within your
       gcloud: talkiq/gcloud@1
       linter: talkiq/linter@1
       notifier: talkiq/notifier@1
+      poetry: talkiq/poetry@1
       tester: talkiq/tester@1
 
     # ... the rest of your config
@@ -36,6 +37,8 @@ orb and the given release type: ``$ORBNAME-{major,minor,patch}``. Please be
 sure to do this only off of commits on master; any other commits on any other
 branches will release `dev versions`_, which should be enough for testing
 pre-merge.
+
+Note that the ``$ORBNAME``, for example, ``"talkiq/linter"``.
 
 .. |deployer| image:: https://img.shields.io/badge/endpoint.svg?url=https://badges.circleci.io/orb/talkiq/deployer&style=flat-square&label=deployer
     :alt: Latest Version
@@ -60,6 +63,10 @@ pre-merge.
 .. |notifier| image:: https://img.shields.io/badge/endpoint.svg?url=https://badges.circleci.io/orb/talkiq/notifier&style=flat-square&label=notifier
     :alt: Latest Version
     :target: https://circleci.com/orbs/registry/orb/talkiq/notifier
+
+.. |poetry| image:: https://img.shields.io/badge/endpoint.svg?url=https://badges.circleci.io/orb/talkiq/poetry&style=flat-square&label=poetry
+    :alt: Latest Version
+    :target: https://circleci.com/orbs/registry/orb/talkiq/poetry
 
 .. |tester| image:: https://img.shields.io/badge/endpoint.svg?url=https://badges.circleci.io/orb/talkiq/tester&style=flat-square&label=tester
     :alt: Latest Version

--- a/poetry/orb.yaml
+++ b/poetry/orb.yaml
@@ -1,0 +1,91 @@
+version: 2.1
+description: "Tools for running poetry commands."
+
+jobs:
+  run:
+    description: >
+      Run an arbitrary command within your poetry environment.
+    docker:
+      - image: python:<<parameters.python_version>>
+    resource_class: <<parameters.resource_class>>
+    parameters:
+      cmd:
+        type: string
+      cwd:
+        default: '.'
+        description: >
+          Working directory for your package. Should point to a folder
+          containing your pyproject.toml file.
+        type: string
+      python_version:
+        default: latest
+        type: string
+      resource_class:
+        default: small
+        type: string
+    steps:
+      - run: python3 -m pip install poetry
+      - run: poetry config http-basic.fury $GEMFURY_TOKEN NOPASS
+      - checkout
+      - run:
+          command: poetry install -n
+          working_directory: <<parameters.cwd>>
+      - run:
+          command: poetry run <<parameters.cmd>>
+          working_directory: <<parameters.cwd>>
+
+  publish:
+    description: >
+      Publishes your package to the specified repository.
+    docker:
+      - image: python:<<parameters.python_version>>
+    resource_class: <<parameters.resource_class>>
+    parameters:
+      cwd:
+        default: '.'
+        description: >
+          Working directory for your package. Should point to a folder
+          containing your pyproject.toml file.
+        type: string
+      python_version:
+        default: latest
+        type: string
+      resource_class:
+        default: small
+        type: string
+      password:
+        description: >
+          Password to be used for authenticating against the specified
+          repository. Note that some indexes such as Gemfury use the username
+          field for your personal access token; in that case, set this value to
+          "NOPASS".
+        type: string
+      repository:
+        default: pypi
+        description: >
+          Name of the repository you wish to upload to. If using a non-default
+          repository, you'll need to define it in your pyproject.toml.
+        type: string
+      username:
+        description: >
+          Username to be used for authenticating against the specified
+          repository.
+        type: string
+    steps:
+      - run: python3 -m pip install poetry
+      - checkout
+      - run:
+          name: validate tag matches pyproject.toml
+          command:
+            if [[ "${CIRCLE_TAG}" != *"$(poetry version | cut -d ' ' -f2)"* ]]; then
+                echo "Version $(poetry version) does not match tag ${CIRCLE_TAG}";
+                exit 1;
+            fi
+          working_directory: <<parameters.cwd>>
+      - run:
+          command: poetry build
+          working_directory: <<parameters.cwd>>
+      - run:
+          name: poetry publish
+          command: poetry publish -r <<parameters.repository>> -u <<parameters.username>> -p <<parameters.password>>
+          working_directory: <<parameters.cwd>>


### PR DESCRIPTION
## Summary
Creates a new orb "poetry" which can be used to run arbitrary commands via poetry (eg. to run pytest on a package) and to publish the package to the given PyPI respository.

Additionally, significantly simplifies our CircleCI config, as that has been getting more unwieldy with each new orb.

### Checklist
- [x] comments/docstrings/type hints are clear
- [x] manual testing has passed