### PR TITLE
feat(gcloud): Support publishing containers from third-party vendors

### DIFF
--- a/gcloud/orb.yaml
+++ b/gcloud/orb.yaml
@@ -397,6 +397,11 @@ jobs:
         description: >
           Extra flags to pass to docker build.
         type: string
+      custom-checkout:
+        default: ''
+        description: >
+          Pull repositories other than tooling for building.
+        type: string
       creds:
         default: GCLOUD_SERVICE_KEY
         description: >
@@ -457,7 +462,14 @@ jobs:
           project: <<parameters.project>>
       - configure-docker:
           docker_layer_caching: <<parameters.docker_layer_caching>>
-      - checkout
+      - when:
+          condition: <<parameters.custom-checkout>>
+          steps:
+            - run: git clone <<parameters.custom-checkout>>
+      - unless:
+          condition: <<parameters.custom-checkout>>
+          steps:
+            - checkout
       - docker/build:
           build_args: <<parameters.build_args>>
           dockerfile: <<parameters.dockerfile>>

--- a/gcloud/orb.yaml
+++ b/gcloud/orb.yaml
@@ -397,10 +397,11 @@ jobs:
         description: >
           Extra flags to pass to docker build.
         type: string
-      custom-checkout:
+      git_repository_url:
         default: ''
         description: >
-          Pull repositories other than tooling for building.
+          If unset, uses the current repository. Otherwise, clones the provided
+          repo's default branch to a depth of 1.
         type: string
       creds:
         default: GCLOUD_SERVICE_KEY
@@ -463,11 +464,11 @@ jobs:
       - configure-docker:
           docker_layer_caching: <<parameters.docker_layer_caching>>
       - when:
-          condition: <<parameters.custom-checkout>>
+          condition: <<parameters.git_repository_url>>
           steps:
-            - run: git clone <<parameters.custom-checkout>>
+            - run: git clone --depth=1 <<parameters.git_repository_url>>
       - unless:
-          condition: <<parameters.custom-checkout>>
+          condition: <<parameters.git_repository_url>>
           steps:
             - checkout
       - docker/build:


### PR DESCRIPTION
## Summary
<!---
Summary of changes. Include any relevant context and complexities. Link any
relevant tickets / branches / other PRs / blockers / etc.
--->

This PR adds support for publishing 3rd party images to Google Cloud. Feature added to support publishing projects not compatible by the CircleCI `checkout`

### Checklist
<!---
See docs.talkiq-echelon.talkiq.com/static/docs/guides/pull-requests.html#guidelines

Feel free to add anything extra to the list as need be or omit items which
do not apply to this changeset.
--->
- [x] comments/docstrings/type hints are clear
- [ ] new tests have been written
- [x] manual testing has passed
- [ ] architecture diagrams have been updated
- [ ] I've included any special rollback strategies above
- [ ] metrics/monitors/alerts/SLOs have been added or modified
