### PR TITLE
feat(docs): create docs archive on every doc build

### DIFF
--- a/docs/orb.yaml
+++ b/docs/orb.yaml
@@ -98,6 +98,11 @@ jobs:
             gsutil -m rm -r gs://<<parameters.gcp_project>>-docs/<<parameters.project>>/ ||:
       - run: gsutil -m cp -r build/* gs://<<parameters.gcp_project>>-docs/<<parameters.project>>/
       # END TODO
+      # recreate archive with all docs
+      - run: mkdir docs
+      - run: gsutil -m cp -r gs://<<parameters.gcp_project>>-docs/ docs/
+      - run: tar -czvf docs.tar.gz docs
+      - run: gsutil -m cp docs.tar.gz gs://<<parameters.gcp_project>>-docs-archive/
 
 orbs:
   gcloud: talkiq/gcloud@1


### PR DESCRIPTION
## Summary
<!---
Summary of changes. Include any relevant context and complexities. Link any
relevant tickets / branches / other PRs / blockers / etc.
--->
Archive all rendered docs on each compile & upload step. This will allow workbench to watch archive, download it on each change and serve as static files. This will allow to:
1. ditch docs cloud-run service
2. update docs immediately rather than daily

### Checklist
<!---
See docs.talkiq-echelon.talkiq.com/static/docs/guides/pull-requests.html#guidelines

Feel free to add anything extra to the list as need be or omit items which
do not apply to this changeset.
--->
- [ ] comments/docstrings/type hints are clear
- [ ] new tests have been written
- [ ] manual testing has passed
- [ ] architecture diagrams have been updated
- [ ] I've included any special rollback strategies above
- [ ] metrics/monitors/alerts/SLOs have been added or modified
