### PR TITLE
chore(poetry): use gemfury token for username/pass

### DIFF
--- a/poetry/orb.yaml
+++ b/poetry/orb.yaml
@@ -25,7 +25,7 @@ jobs:
         type: string
     steps:
       - run: python3 -m pip install poetry
-      - run: poetry config http-basic.fury $GEMFURY_TOKEN NOPASS
+      - run: poetry config http-basic.fury $GEMFURY_TOKEN $GEMFURY_TOKEN
       - checkout
       - run:
           command: poetry install -n --no-ansi
@@ -58,7 +58,7 @@ jobs:
           Password to be used for authenticating against the specified
           repository. Note that some indexes such as Gemfury use the username
           field for your personal access token; in that case, set this value to
-          "NOPASS".
+          the same value as the username.
         type: string
       repository:
         default: pypi


### PR DESCRIPTION
## Summary
<!---
Summary of changes. Include any relevant context and complexities. Link any
relevant tickets / branches / other PRs / blockers / etc.
--->

I think that regardless of our resolution steps to Gemfury `404` issues, we should use the same convention that Gemfury suggests.
