### PR TITLE
fix(linter): paged output can cause long timeouts

### DIFF
--- a/linter/orb.yaml
+++ b/linter/orb.yaml
@@ -44,7 +44,7 @@ commands:
       - run: pre-commit run --all-files -c <<parameters.config_file>>
       - run:
           name: git diff
-          command: git diff
+          command: git --no-pager diff
           when: on_fail
 
 jobs:


### PR DESCRIPTION
## Summary
You know when you `git diff` and the output is paged by default which is usually nice? Apparently this causes issues as circle waits to receive the full output, which never arrives and we end up timing out after 10 minutes. For instance, see this [failed job](https://app.circleci.com/pipelines/github/talkiq/realtime-decoder/5752/workflows/f44b95af-1efc-4556-b1d7-304fc128a293/jobs/47918).
