### PR TITLE
bug(gcloud): Prevent double-install error

### DIFF
--- a/gcloud/orb.yaml
+++ b/gcloud/orb.yaml
@@ -166,7 +166,6 @@ commands:
         type: string
     steps:
       - run: python3 -m pip install twine keyring keyrings.google-artifactregistry-auth
-      - install
       - auth:
           creds: <<parameters.creds>>
           project: <<parameters.project>>


### PR DESCRIPTION
## Summary
<!---
Summary of changes. Include any relevant context and complexities. Link any
relevant tickets / branches / other PRs / blockers / etc.
--->

When publishing twice, `install` causes errors because Google SDK already installed

### Checklist
<!---
See docs.talkiq-echelon.talkiq.com/static/docs/guides/pull-requests.html#guidelines

Feel free to add anything extra to the list if need be!
--->
- [ ] My comments/docstrings/type hints are clear
- [ ] I've written new tests or this change does not need them
- [ ] I've tested this manually
- [ ] The architecture diagrams have been updated, if need be
- [ ] I've included any special rollback strategies above
- [ ] Any relevant metrics/monitors/SLOs have been added or modified
- [ ] I've notified all relevant stakeholders of the change
