### PR TITLE
chore: bump remote docker version to 20.10.6

### DIFF
--- a/docker/orb.yaml
+++ b/docker/orb.yaml
@@ -383,7 +383,7 @@ jobs:
           Name of dockerfile to use.
         type: string
       executor:
-        default: docker:19.03.12-git
+        default: docker:20.10.6-git
         description: >
           Name of the docker image to use to execute the job.
         type: string

--- a/gcloud/orb.yaml
+++ b/gcloud/orb.yaml
@@ -464,7 +464,7 @@ jobs:
           Name of dockerfile to use.
         type: string
       executor:
-        default: docker:19.03.12-git
+        default: docker:20.10.6-git
         description: >
           Name of the docker image to use to execute the job.
         type: string

--- a/gcloud/orb.yaml
+++ b/gcloud/orb.yaml
@@ -43,13 +43,13 @@ commands:
           condition: <<parameters.docker_layer_caching>>
           steps:
             - setup_remote_docker:
-                version: 19.03.12
+                version: 20.10.6
                 docker_layer_caching: true
       - unless:
           condition: <<parameters.docker_layer_caching>>
           steps:
             - setup_remote_docker:
-                version: 19.03.12
+                version: 20.10.6
       - run: gcloud auth configure-docker --quiet
 
   configure-gke:

--- a/tester/orb.yaml
+++ b/tester/orb.yaml
@@ -207,7 +207,7 @@ jobs:
             and: [<<parameters.gcr_creds>>, <<parameters.gcr_project>>]
           steps:
             - setup_remote_docker:
-                version: 19.03.12
+                version: 20.10.6
       - checkout
       - run:
           working_directory: <<parameters.cwd>>


### PR DESCRIPTION
## Summary
<!---
Summary of changes. Include any relevant context and complexities. Link any
relevant tickets / branches / other PRs / blockers / etc.
--->
How it started: https://dialpad.slack.com/archives/GA91FTLDU/p1623882936426100
How it's going: https://dialpad.slack.com/archives/GA91FTLDU/p1623889383442900

Tested on tooling: https://app.circleci.com/pipelines/github/talkiq/tooling/9734/workflows/0d2e7bf0-321d-4a25-ac3f-a0623b50e177

Let me know which repos you think might be at risk and worth testing

### Checklist
<!---
See docs.talkiq-echelon.talkiq.com/static/docs/guides/pull-requests.html#guidelines

Feel free to add anything extra to the list if need be!
--->
- [ ] My comments/docstrings/type hints are clear
- [ ] I've written new tests or this change does not need them
- [x] I've tested this manually
- [ ] The architecture diagrams have been updated, if need be
- [ ] I've included any special rollback strategies above
- [ ] Any relevant metrics/monitors/SLOs have been added or modified
- [ ] I've notified all relevant stakeholders of the change
