### PR TITLE
feat(notifier): support custom datadog domains

### DIFF
--- a/notifier/orb.yaml
+++ b/notifier/orb.yaml
@@ -18,6 +18,11 @@ jobs:
         description: |
           Name of the environment variable containing your Datadog API key.
         type: env_var_name
+      domain:
+        default: "api.datadoghq.com"
+        description: |
+          Domain name of the Datadog ingestion API.
+        type: string
       tag:
         default: ""
         description: |
@@ -37,7 +42,7 @@ jobs:
           curl -XPOST \
             -H "Content-Type: application/json" \
             -d '{"title": "'"<<parameters.title>>"'", "text": "'"<<parameters.text>>"'", "tags": ["'"<<parameters.tag>>"'"], "alert_type": "success"}' \
-            "https://api.datadoghq.com/api/v1/events?api_key=${<<parameters.api_key>>}"
+            "https://<<parameters.domain>>/api/v1/events?api_key=${<<parameters.api_key>>}"
 
   sentry-deployment:
     description: |


### PR DESCRIPTION
## Summary
Apparently, there's now an api.datadoghq.eu for folks in the EU. May as
well broaden this up to support that override if anyone external needs
it.

### Checklist
- [x] My comments/docstrings/type hints are clear
- [x] I've written new tests or this change does not need them
- [x] I've tested this manually
- [x] The architecture diagrams have been updated, if need be
- [x] I've included any special rollback strategies above
- [x] Any relevant metrics/monitors/SLOs have been added or modified
- [x] I've notified all relevant stakeholders of the change