### PR TITLE
fix(gcloud): link kubectl cli tool

### DIFF
--- a/gcloud/orb.yaml
+++ b/gcloud/orb.yaml
@@ -72,7 +72,7 @@ commands:
             equal: [ <<parameters.kubectl_version>>, "gcloud-latest" ]
           steps:
             - run: echo y | gcloud components install kubectl
-            - run: ln -s /root/google-cloud-sdk/bin/kubectl /usr/bin/kubectl
+            - run: ln -s /root/google-cloud-sdk/bin/kubectl /usr/local/bin/kubectl
       - when:
           condition:
             equal: [ <<parameters.kubectl_version>>, "latest" ]

--- a/gcloud/orb.yaml
+++ b/gcloud/orb.yaml
@@ -72,6 +72,7 @@ commands:
             equal: [ <<parameters.kubectl_version>>, "gcloud-latest" ]
           steps:
             - run: echo y | gcloud components install kubectl
+            - run: ln -s /root/google-cloud-sdk/bin/kubectl /usr/bin/kubectl
       - when:
           condition:
             equal: [ <<parameters.kubectl_version>>, "latest" ]


### PR DESCRIPTION
## Summary
<!---
Summary of changes. Include any relevant context and complexities. Link any
relevant tickets / branches / other PRs / blockers / etc.
--->

Looks like `kubectl` needs to be linked in the same way as `gcloud` needs to be linked. This wasn't apparent before but since `kubectl client --version` was added as a step recently (https://github.com/talkiq/circleci-orbs/pull/52) this showed up in our CI failures (and I was able to reproduce the behaviour locally within an isolated docker environment).

```
#!/bin/bash -eo pipefail
kubectl version --client
/bin/bash: kubectl: command not found
Exited with code exit status 127
CircleCI received exit code 127
```
