### PR TITLE
feat(gcloud): add pre_build_steps to docker-publish

### DIFF
--- a/gcloud/orb.yaml
+++ b/gcloud/orb.yaml
@@ -508,6 +508,11 @@ jobs:
         description: >
           Path to the build context directory containing your Dockerfile.
         type: string
+      pre_build_steps:
+        default: []
+        description: >
+          Pre-steps to be executed after gcloud authentication
+        type: steps
       project:
         description: >
           Name of GCP project to which we will push.
@@ -541,6 +546,7 @@ jobs:
           condition: <<parameters.git_repository_url>>
           steps:
             - checkout
+      - steps: <<parameters.pre_build_steps>>
       - docker/build:
           build_args: <<parameters.build_args>>
           dockerfile: <<parameters.dockerfile>>


### PR DESCRIPTION
## Summary
<!---
Summary of changes. Include any relevant context and complexities. Link any
relevant tickets / branches / other PRs / blockers / etc.
--->
A follow up for https://github.com/talkiq/tooling/pull/1551#discussion_r694330604

### Checklist
<!---
See docs.talkiq-echelon.talkiq.com/static/docs/guides/pull-requests.html#guidelines

Feel free to add anything extra to the list if need be!
--->
- [ ] My comments/docstrings/type hints are clear
- [ ] I've written new tests or this change does not need them
- [ ] I've tested this manually
- [ ] The architecture diagrams have been updated, if need be
- [ ] I've included any special rollback strategies above
- [ ] Any relevant metrics/monitors/SLOs have been added or modified
- [ ] I've notified all relevant stakeholders of the change
