### PR TITLE
feat(circleci): Build and publish python packages separetely

### DIFF
--- a/gcloud/orb.yaml
+++ b/gcloud/orb.yaml
@@ -208,9 +208,9 @@ commands:
 jobs:
   artifact-registry-publish-python-package:
     description: >
-      Publish Python package to Artifact Registry package repository
+      Publish Python package to Artifact Registry package repository from workspace.
     docker:
-      - image: python:3.7.10
+      - image: python:<<parameters.python_version>>
     resource_class: <<parameters.resource_class>>
     parameters:
       creds:
@@ -219,19 +219,26 @@ jobs:
           Name of environment variable storing the base64-encoded service key
           for the GCP project.
         type: env_var_name
+      cwd:
+        default: '.'
+        description: >
+          Working directory containing 'dist'.
       files:
         default: '*'
         description: >
           Glob pattern of files to upload
         type: string
       path:
-        default: '/tmp/workspaces/dist'
+        default: 'dist'
         description: >
           Path to the directory containing your packages.
         type: string
       project:
         description: >
           Name of GCP project to which we will push.
+        type: string
+      python_version:
+        default: latest
         type: string
       repository-url:
         description: >
@@ -240,11 +247,6 @@ jobs:
       resource_class:
         default: small
         type: string
-      workspace:
-        default: '/tmp/workspaces'
-        description: >
-          Workspace to retrieve packages from
-        type: string
     steps:
       - run: python3 -m pip install twine keyring keyrings.google-artifactregistry-auth
       - install
@@ -252,15 +254,19 @@ jobs:
           creds: <<parameters.creds>>
           project: <<parameters.project>>
       - attach_workspace:
-            at: <<parameters.workspace>>
-      - run: |
-          unset TWINE_PASSWORD
-          unset TWINE_USERNAME
-          unset TWINE_REPOSITORY
-          unset TWINE_REPOSITORY_URL
-          unset TWINE_CERT
-          unset TWINE_NON_INTERACTIVE
-          twine upload --repository-url <<parameters.repository-url>> <<parameters.path>>/<<parameters.files>>
+            at: <<parameters.cwd>>
+      - run:
+          name: Upload package from workspace
+          command: |
+            unset TWINE_PASSWORD
+            unset TWINE_USERNAME
+            unset TWINE_REPOSITORY
+            unset TWINE_REPOSITORY_URL
+            unset TWINE_CERT
+            unset TWINE_NON_INTERACTIVE
+            twine upload --repository-url <<parameters.repository-url>> <<parameters.path>>/<<parameters.files>>
+          working_directory: <<parameters.cwd>>
+
   deploy-cloud-function:
     description: >
       Deploy a package to Google's Cloud Function service.

--- a/gcloud/orb.yaml
+++ b/gcloud/orb.yaml
@@ -223,6 +223,7 @@ jobs:
         default: '.'
         description: >
           Working directory containing 'dist'.
+        type: string
       files:
         default: '*'
         description: >

--- a/gcloud/orb.yaml
+++ b/gcloud/orb.yaml
@@ -206,6 +206,61 @@ commands:
           twine upload --repository-url <<parameters.repository-url>> <<parameters.path>>/<<parameters.files>>
 
 jobs:
+  artifact-registry-publish-python-package:
+    description: >
+      Publish Python package to Artifact Registry package repository
+    docker:
+      - image: python:3.7.10
+    resource_class: <<parameters.resource_class>>
+    parameters:
+      creds:
+        default: GCLOUD_SERVICE_KEY
+        description: >
+          Name of environment variable storing the base64-encoded service key
+          for the GCP project.
+        type: env_var_name
+      files:
+        default: '*'
+        description: >
+          Glob pattern of files to upload
+        type: string
+      path:
+        default: '/tmp/workspaces/dist'
+        description: >
+          Path to the directory containing your packages.
+        type: string
+      project:
+        description: >
+          Name of GCP project to which we will push.
+        type: string
+      repository-url:
+        description: >
+          URL of GCP package repository to which we will push.
+        type: string
+      resource_class:
+        default: small
+        type: string
+      workspace:
+        default: '/tmp/workspaces'
+        description: >
+          Workspace to retrieve packages from
+        type: string
+    steps:
+      - run: python3 -m pip install twine keyring keyrings.google-artifactregistry-auth
+      - install
+      - auth:
+          creds: <<parameters.creds>>
+          project: <<parameters.project>>
+      - attach_workspace:
+            at: <<parameters.workspace>>
+      - run: |
+          unset TWINE_PASSWORD
+          unset TWINE_USERNAME
+          unset TWINE_REPOSITORY
+          unset TWINE_REPOSITORY_URL
+          unset TWINE_CERT
+          unset TWINE_NON_INTERACTIVE
+          twine upload --repository-url <<parameters.repository-url>> <<parameters.path>>/<<parameters.files>>
   deploy-cloud-function:
     description: >
       Deploy a package to Google's Cloud Function service.

--- a/gcloud/orb.yaml
+++ b/gcloud/orb.yaml
@@ -205,13 +205,9 @@ commands:
           unset TWINE_NON_INTERACTIVE
           twine upload --repository-url <<parameters.repository-url>> <<parameters.path>>/<<parameters.files>>
 
-jobs:
-  artifact-registry-publish-python-package:
+  auth-with-artifact-registry:
     description: >
-      Publish Python package to Artifact Registry package repository from workspace.
-    docker:
-      - image: python:<<parameters.python_version>>
-    resource_class: <<parameters.resource_class>>
+      Install artifact registry keyring infrastructure
     parameters:
       creds:
         default: GCLOUD_SERVICE_KEY
@@ -219,55 +215,17 @@ jobs:
           Name of environment variable storing the base64-encoded service key
           for the GCP project.
         type: env_var_name
-      cwd:
-        default: '.'
-        description: >
-          Working directory containing 'dist'.
-        type: string
-      files:
-        default: '*'
-        description: >
-          Glob pattern of files to upload
-        type: string
-      path:
-        default: 'dist'
-        description: >
-          Path to the directory containing your packages.
-        type: string
       project:
         description: >
           Name of GCP project to which we will push.
-        type: string
-      python_version:
-        default: latest
-        type: string
-      repository-url:
-        description: >
-          URL of GCP package repository to which we will push.
-        type: string
-      resource_class:
-        default: small
-        type: string
     steps:
-      - run: python3 -m pip install twine keyring keyrings.google-artifactregistry-auth
       - install
+      - run: python3 -m pip install keyring keyrings.google-artifactregistry-auth
       - auth:
           creds: <<parameters.creds>>
           project: <<parameters.project>>
-      - attach_workspace:
-            at: <<parameters.cwd>>
-      - run:
-          name: Upload package from workspace
-          command: |
-            unset TWINE_PASSWORD
-            unset TWINE_USERNAME
-            unset TWINE_REPOSITORY
-            unset TWINE_REPOSITORY_URL
-            unset TWINE_CERT
-            unset TWINE_NON_INTERACTIVE
-            twine upload --repository-url <<parameters.repository-url>> <<parameters.path>>/<<parameters.files>>
-          working_directory: <<parameters.cwd>>
 
+jobs:
   deploy-cloud-function:
     description: >
       Deploy a package to Google's Cloud Function service.

--- a/poetry/orb.yaml
+++ b/poetry/orb.yaml
@@ -2,44 +2,6 @@ version: 2.1
 description: "Tools for running poetry commands."
 
 jobs:
-  build:
-    description: >
-      Build your package and store to shared workspace.
-    docker:
-      - image: python:<<parameters.python_version>>
-    resource_class: <<parameters.resource_class>>
-    parameters:
-      cwd:
-        default: '.'
-        description: >
-          Working directory for your package. Should point to a folder
-          containing your pyproject.toml file.
-        type: string
-      python_version:
-        default: latest
-        type: string
-      resource_class:
-        default: small
-        type: string
-    steps:
-      - run: python3 -m pip install poetry
-      - checkout
-      - run:
-          name: validate tag matches pyproject.toml
-          command:
-            if [[ "${CIRCLE_TAG}" != *"$(poetry version | cut -d ' ' -f2)"* ]]; then
-                echo "Version $(poetry version) does not match tag ${CIRCLE_TAG}";
-                exit 1;
-            fi
-          working_directory: <<parameters.cwd>>
-      - run:
-          command: poetry build
-          working_directory: <<parameters.cwd>>
-      - persist_to_workspace:
-          root: <<parameters.cwd>>
-          paths:
-            - dist
-
   run:
     description: >
       Run an arbitrary command within your poetry environment.

--- a/poetry/orb.yaml
+++ b/poetry/orb.yaml
@@ -4,7 +4,7 @@ description: "Tools for running poetry commands."
 jobs:
   build:
     description: >
-      Publishes your package to the specified repository.
+      Build your package and store to shared workspace.
     docker:
       - image: python:<<parameters.python_version>>
     resource_class: <<parameters.resource_class>>
@@ -21,11 +21,6 @@ jobs:
       resource_class:
         default: small
         type: string
-      workspace:
-        default: '/tmp/workspaces'
-        description: >
-          Workspace to retrieve packages from
-        type: string
     steps:
       - run: python3 -m pip install poetry
       - checkout
@@ -40,11 +35,8 @@ jobs:
       - run:
           command: poetry build
           working_directory: <<parameters.cwd>>
-      - run: |
-          mkdir -p <<parameters.workspace>>
-          cp -r dist <<parameters.workspace>>/dist
       - persist_to_workspace:
-          root: <<parameters.workspace>>
+          root: <<parameters.cwd>>
           paths:
             - dist
 

--- a/poetry/orb.yaml
+++ b/poetry/orb.yaml
@@ -2,6 +2,52 @@ version: 2.1
 description: "Tools for running poetry commands."
 
 jobs:
+  build:
+    description: >
+      Publishes your package to the specified repository.
+    docker:
+      - image: python:<<parameters.python_version>>
+    resource_class: <<parameters.resource_class>>
+    parameters:
+      cwd:
+        default: '.'
+        description: >
+          Working directory for your package. Should point to a folder
+          containing your pyproject.toml file.
+        type: string
+      python_version:
+        default: latest
+        type: string
+      resource_class:
+        default: small
+        type: string
+      workspace:
+        default: '/tmp/workspaces'
+        description: >
+          Workspace to retrieve packages from
+        type: string
+    steps:
+      - run: python3 -m pip install poetry
+      - checkout
+      - run:
+          name: validate tag matches pyproject.toml
+          command:
+            if [[ "${CIRCLE_TAG}" != *"$(poetry version | cut -d ' ' -f2)"* ]]; then
+                echo "Version $(poetry version) does not match tag ${CIRCLE_TAG}";
+                exit 1;
+            fi
+          working_directory: <<parameters.cwd>>
+      - run:
+          command: poetry build
+          working_directory: <<parameters.cwd>>
+      - run: |
+          mkdir -p <<parameters.workspace>>
+          cp -r dist <<parameters.workspace>>/dist
+      - persist_to_workspace:
+          root: <<parameters.workspace>>
+          paths:
+            - dist
+
   run:
     description: >
       Run an arbitrary command within your poetry environment.


### PR DESCRIPTION
## Summary
<!---
Summary of changes. Include any relevant context and complexities. Link any
relevant tickets / branches / other PRs / blockers / etc.
--->

Add an authorization command runnable from an alpine or debian based package. Considering using pre-steps exclusively.

<!-- 
This feature change provides a separate `poetry build` and GCP PyPI upload mechanism. Rather than change the existing CircleCI TalkIQ poetry orb `publish` job and risk breaking existing builds, I have created a separate job `build` job that stores the `dist` build directory to the shared CircleCI Workspace. Similarly, to facilitate the GCP-specific upload to artifact registry, I have created a gcloud job called `artifact-registry-publish-python-package` that deploys builds from the specified workspace. 

### Motivation

GCP Artifact Registry does not use long-lived keys for authentication and instead uses short-lived tokens retrieved (generated?) from a local keyring. Since `poetry` does not support keyrings, nor have built in authentication support for any cloud vendor (i.e. the `gcloud` authentication bit), I thought it likely that separating the build from the publish would yield a clean and maintainable long-term solution for the new short-lived-authentication-token world.

### Design Trade-offs

I did not want to add a dependency between orbs to facilitate the keyring functionality into the poetry orb. Consider the case of using conditional logic to have the existing `publish` job use the GCP keyring if available. This would have required either duplicating a good deal of gcloud orb's code or adding gcloud as a dependency to the poetry orb. I reasoned this would contaminate the poetry orb with unwanted assumptions already handled by our gcloud orb.

I also evaluated the case of creating commands instead of jobs to support the functionality. In the gcloud orb, we currently have `artifacts-package-publish`, all that would be necessary would be to create a similar command for `build` in `gcloud` to faciliate the creation thereby obviating the need for workspace (and saving time). The downside to this approach is that it requires each CircleCI configuration dependent on the gcloud and poetry orb to declare a job to run in a workflow (or require dependencies between orbs, or creating a new orb that depends on both, etc). This would require a lot of boiler plate code in downstream dependents that was prone to breakage if GCP or poetry changed (more times a `sed` command might do something wrong).

Creating two jobs, one in each orb, felt cleanest because it completely maintained legacy behaviour and allowed for us to be able to support other package repository vendors (i.e. Azure, AWS) without needing to keep modifying the poetry orb `publish` production code (i.e. rather than change `publish` in the poetry orb, we simply create an [, say,] azure orb that handles the azure-specific upload and configuration).

#### A special note on Twine

Why is `twine` used, again? Twine is used because `poetry` version 1.1.8 requires a hack to authenticate. For local workstations, this feels acceptable, but for repeatable deployments, `twine` works well and has production-level support for GCP's keyring, no hacks required.

Eventually, we can consider substituting `poetry` for `twine`, but for the time being, I would suggest the hack-free authentication through `twine`.
-->
## Future Work

* Remove the `artifacts-package-publish` command once `algorithms`'s `config.yaml` no longer depends on it.

## Checklist
<!---
See docs.talkiq-echelon.talkiq.com/static/docs/guides/pull-requests.html#guidelines

Feel free to add anything extra to the list if need be!
--->
- [x] My comments/docstrings/type hints are clear
- [ ] I've written new tests or this change does not need them
- [x] I've tested this manually
- [ ] The architecture diagrams have been updated, if need be
- [x] I've included any special rollback strategies above
- [ ] Any relevant metrics/monitors/SLOs have been added or modified
- [ ] I've notified all relevant stakeholders of the change
