### PR TITLE
feat(gcloud): Support calling install command multiple times

### DIFF
--- a/gcloud/orb.yaml
+++ b/gcloud/orb.yaml
@@ -98,10 +98,6 @@ commands:
       Install the Google Cloud SDK on a supported executor. Currently supported
       package managers: apk, apt-get.
     steps:
-      - run: |
-          if [ -f /root/google-cloud-sdk ]; then
-            circleci-agent step halt
-          fi
       - run:
           name: install dependencies
           command: |
@@ -114,10 +110,22 @@ commands:
               echo >&2 "ERROR: could not find supported package manager"
               exit 1
             fi
-      - run: curl -sSL https://sdk.cloud.google.com | bash -s -- --disable-prompts
-      - run: ln -s /root/google-cloud-sdk/bin/gcloud /usr/bin/gcloud
-      - run: ln -s /root/google-cloud-sdk/bin/gsutil /usr/bin/gsutil
-      - run: ln -s /root/google-cloud-sdk/bin/docker-credential-gcloud /usr/bin/docker-credential-gcloud
+      - run: |
+          if [ ! -d /root/google-cloud-sdk ]; then
+            curl -sSL https://sdk.cloud.google.com | bash -s -- --disable-prompts
+          fi
+      - run: |
+          if [ ! -f /usr/bin/gcloud ]; then
+            ln -s /root/google-cloud-sdk/bin/gcloud /usr/bin/gcloud
+          fi
+      - run: |
+          if [ ! -f /usr/bin/gsutil ]; then
+            ln -s /root/google-cloud-sdk/bin/gsutil /usr/bin/gsutil
+          fi
+      - run: |
+          if [ ! -f /usr/bin/docker-credential-gcloud ]; then
+            ln -s /root/google-cloud-sdk/bin/docker-credential-gcloud /usr/bin/docker-credential-gcloud
+          fi
 
   patch-configmap-entry:
     description: >

--- a/gcloud/orb.yaml
+++ b/gcloud/orb.yaml
@@ -110,10 +110,10 @@ commands:
               echo >&2 "ERROR: could not find supported package manager"
               exit 1
             fi
-      - run: curl -sSL https://sdk.cloud.google.com | bash -s -- --disable-prompts
-      - run: ln -s /root/google-cloud-sdk/bin/gcloud /usr/bin/gcloud
-      - run: ln -s /root/google-cloud-sdk/bin/gsutil /usr/bin/gsutil
-      - run: ln -s /root/google-cloud-sdk/bin/docker-credential-gcloud /usr/bin/docker-credential-gcloud
+      - run: \[ ! -f /root/google-cloud-sdk \] && curl -sSL https://sdk.cloud.google.com | bash -s -- --disable-prompts
+      - run: \[ ! -f /usr/bin/gcloud \] && ln -s /root/google-cloud-sdk/bin/gcloud /usr/bin/gcloud
+      - run: \[ ! -f /usr/bin/gsutil \] && ln -s /root/google-cloud-sdk/bin/gsutil /usr/bin/gsutil
+      - run: \[ ! -f /usr/bin/docker-credential-gcloud \] && ln -s /root/google-cloud-sdk/bin/docker-credential-gcloud /usr/bin/docker-credential-gcloud
 
   patch-configmap-entry:
     description: >

--- a/gcloud/orb.yaml
+++ b/gcloud/orb.yaml
@@ -98,6 +98,10 @@ commands:
       Install the Google Cloud SDK on a supported executor. Currently supported
       package managers: apk, apt-get.
     steps:
+      - run: |
+          if [ -f /root/google-cloud-sdk ]; then
+            circleci-agent step halt
+          fi
       - run:
           name: install dependencies
           command: |
@@ -110,10 +114,10 @@ commands:
               echo >&2 "ERROR: could not find supported package manager"
               exit 1
             fi
-      - run: \[ ! -f /root/google-cloud-sdk \] && curl -sSL https://sdk.cloud.google.com | bash -s -- --disable-prompts
-      - run: \[ ! -f /usr/bin/gcloud \] && ln -s /root/google-cloud-sdk/bin/gcloud /usr/bin/gcloud
-      - run: \[ ! -f /usr/bin/gsutil \] && ln -s /root/google-cloud-sdk/bin/gsutil /usr/bin/gsutil
-      - run: \[ ! -f /usr/bin/docker-credential-gcloud \] && ln -s /root/google-cloud-sdk/bin/docker-credential-gcloud /usr/bin/docker-credential-gcloud
+      - run: curl -sSL https://sdk.cloud.google.com | bash -s -- --disable-prompts
+      - run: ln -s /root/google-cloud-sdk/bin/gcloud /usr/bin/gcloud
+      - run: ln -s /root/google-cloud-sdk/bin/gsutil /usr/bin/gsutil
+      - run: ln -s /root/google-cloud-sdk/bin/docker-credential-gcloud /usr/bin/docker-credential-gcloud
 
   patch-configmap-entry:
     description: >


### PR DESCRIPTION
## Summary
<!---
Summary of changes. Include any relevant context and complexities. Link any
relevant tickets / branches / other PRs / blockers / etc.
--->

Enable `gcloud/install` to be called multiple times without error. This is change will be published as a patch since it should result in a no-op, unless (!!) a caller of this code used a `when` statement with `on_failure`. I have not found `when` and `gcloud/install` used in this manner.

### Checklist
<!---
See docs.talkiq-echelon.talkiq.com/static/docs/guides/pull-requests.html#guidelines

Feel free to add anything extra to the list if need be!
--->
- [ ] My comments/docstrings/type hints are clear
- [ ] I've written new tests or this change does not need them
- [x] I've tested this manually
- [ ] The architecture diagrams have been updated, if need be
- [ ] I've included any special rollback strategies above
- [ ] Any relevant metrics/monitors/SLOs have been added or modified
- [ ] I've notified all relevant stakeholders of the change
