### PR TITLE
chore(renovate): Enable updating renovate orbs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": ["github>talkiq/common"],
-  "orbs": {
+  "circleci": {
     "fileMatch": ["(^|/)orb\\.ya?ml$"]
   }
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,3 +1,6 @@
 {
-  "extends": ["github>talkiq/common"]
+  "extends": ["github>talkiq/common"],
+  "orbs": {
+    "fileMatch": ["(^|/)orb\\.ya?ml$"]
+  }
 }


### PR DESCRIPTION
## Summary
<!---
Summary of changes. Include any relevant context and complexities. Link any
relevant tickets / branches / other PRs / blockers / etc.
--->

Enable updating the orbs via extending supported file types.

We must specify `circleci` as the manager because `orb` is a datasource, not a manager. See https://docs.renovatebot.com/modules/manager/circleci/.

### Checklist
<!---
See docs.talkiq-echelon.talkiq.com/static/docs/guides/pull-requests.html#guidelines

Feel free to add anything extra to the list if need be!
--->
- [ ] My comments/docstrings/type hints are clear
- [ ] I've written new tests or this change does not need them
- [ ] I've tested this manually
- [ ] The architecture diagrams have been updated, if need be
- [ ] I've included any special rollback strategies above
- [ ] Any relevant metrics/monitors/SLOs have been added or modified
- [ ] I've notified all relevant stakeholders of the change
