### PR TITLE
chore(cirlceci): Revert orb-tools version due to publish failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  orb-tools: circleci/orb-tools@8
+  orb-tools: circleci/orb-tools@7.3.0
   linter: talkiq/linter@volatile
 
 workflows:


### PR DESCRIPTION
## Summary
<!---
Summary of changes. Include any relevant context and complexities. Link any
relevant tickets / branches / other PRs / blockers / etc.
--->

Unable to promote `talkiq/tester` to production after upgrading to `orb-tools@8`. Reverting change before further troubleshooting.

### Checklist
<!---
See docs.talkiq-echelon.talkiq.com/static/docs/guides/pull-requests.html#guidelines

Feel free to add anything extra to the list if need be!
--->
- [ ] My comments/docstrings/type hints are clear
- [ ] I've written new tests or this change does not need them
- [ ] I've tested this manually
- [ ] The architecture diagrams have been updated, if need be
- [ ] I've included any special rollback strategies above
- [ ] Any relevant metrics/monitors/SLOs have been added or modified
- [ ] I've notified all relevant stakeholders of the change
