### PR TITLE
feat(tester): Add build arguments to docker-compose build

### DIFF
--- a/tester/orb.yaml
+++ b/tester/orb.yaml
@@ -157,6 +157,7 @@ jobs:
         default: ''
         description: >
           Docker-compose build args such as build enviornment variables.
+        type: string
       cwd:
         default: '.'
         description: >

--- a/tester/orb.yaml
+++ b/tester/orb.yaml
@@ -156,7 +156,7 @@ jobs:
       build_args:
         default: ''
         description: >
-          Docker-compose build args such as build enviornment variables.
+          Extra flags to pass to docker build.
         type: string
       cwd:
         default: '.'

--- a/tester/orb.yaml
+++ b/tester/orb.yaml
@@ -153,7 +153,7 @@ jobs:
         description: |
           Services to build besides target service
         type: string
-      build_args:
+      build_options:
         default: ''
         description: >
           Extra flags to pass to docker build.
@@ -217,7 +217,7 @@ jobs:
       - run:
           working_directory: <<parameters.cwd>>
           # has to be built explicitly https://github.com/docker/compose/issues/7336
-          command: docker-compose <<parameters.compose_args>> build <<parameters.build_args>> <<parameters.service_name>> <<parameters.build>>
+          command: docker-compose <<parameters.compose_args>> build <<parameters.build_options>> <<parameters.service_name>> <<parameters.build>>
           environment:
             DOCKER_BUILDKIT: 1
             COMPOSE_DOCKER_CLI_BUILD: 1

--- a/tester/orb.yaml
+++ b/tester/orb.yaml
@@ -153,6 +153,10 @@ jobs:
         description: |
           Services to build besides target service
         type: string
+      build_args:
+        default: ''
+        description: >
+          Docker-compose build args such as build enviornment variables.
       cwd:
         default: '.'
         description: >
@@ -212,7 +216,7 @@ jobs:
       - run:
           working_directory: <<parameters.cwd>>
           # has to be built explicitly https://github.com/docker/compose/issues/7336
-          command: docker-compose <<parameters.compose_args>> build <<parameters.service_name>> <<parameters.build>>
+          command: docker-compose <<parameters.compose_args>> build <<parameters.build_args>> <<parameters.service_name>> <<parameters.build>>
           environment:
             DOCKER_BUILDKIT: 1
             COMPOSE_DOCKER_CLI_BUILD: 1


### PR DESCRIPTION
## Summary
<!---
Summary of changes. Include any relevant context and complexities. Link any
relevant tickets / branches / other PRs / blockers / etc.
--->

Support passing arguments to `docker-compose build` such as `--build-args`.

### Checklist
<!---
See docs.talkiq-echelon.talkiq.com/static/docs/guides/pull-requests.html#guidelines

Feel free to add anything extra to the list if need be!
--->
- [x] My comments/docstrings/type hints are clear
- [x] I've written new tests or this change does not need them
- [x] I've tested this manually
- [ ] The architecture diagrams have been updated, if need be
- [ ] I've included any special rollback strategies above
- [ ] Any relevant metrics/monitors/SLOs have been added or modified
- [ ] I've notified all relevant stakeholders of the change
