### PR TITLE
fix(gcloud): Update kubectl install command

### DIFF
--- a/gcloud/orb.yaml
+++ b/gcloud/orb.yaml
@@ -71,7 +71,7 @@ commands:
           condition:
             equal: [ <<parameters.kubectl_version>>, "gcloud-latest" ]
           steps:
-            - run: echo y | gcloud components install kubectl
+            - run: gcloud components install --quiet kubectl
             - run: ln -s /root/google-cloud-sdk/bin/kubectl /usr/local/bin/kubectl
       - when:
           condition:


### PR DESCRIPTION
## Summary

@harsh-dialpad — migrated your change set over here, since a branch here is able to pass circle's tests.
• from: https://github.com/talkiq/circleci-orbs/pull/68
• tested w commit in a client app: https://github.com/talkiq/realtime-nlp/commit/6d6e9d13dd0af4d506a084f828669381d1b22706
• verified the new kubectl semantics works: https://app.circleci.com/pipelines/github/talkiq/realtime-nlp/6704/workflows/16d017dc-5015-4bd8-851a-dc4c9c38a3d8/jobs/85080/parallel-runs/0/steps/0-110

### Checklist
🚫 My comments/docstrings/type hints are clear
🚫 I've written new tests or this change does not need them
✅ I've tested this manually
🚫 The architecture diagrams have been updated, if need be
🚫 I've included any special rollback strategies above
🚫 Any relevant metrics/monitors/SLOs have been added or modified
✅ I've notified all relevant stakeholders of the change


