### PR TITLE
chore(github): update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,4 @@
 *                   @talkiq/engineering-any @TheKevJames
+
+pyproject.toml      @TheKevJames
+poetry.lock         @TheKevJames

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,3 +17,4 @@ Feel free to add anything extra to the list if need be!
 - [ ] I've included any special rollback strategies above
 - [ ] Any relevant metrics/monitors/SLOs have been added or modified
 - [ ] I've notified all relevant stakeholders of the change
+- [ ] I've updated .github/CODEOWNERS, if relevant


### PR DESCRIPTION
## Summary
As decided in our previous retro, update our CODEOWNERS file to include more explicit ownership on PRs. I've started by tossing in my own stuff (handling renovate PRs), but it would be great to get everyone to add themselves as appropriate to get us "caught up". Note I've also updated the PR template in `docs` to remind us to keep this up-to-date: if folks approve that change, I'll mirror it to this PR.

## Checklist
* [x] @TheKevJames
* [x] @allandialpad
* [x] @caseydialpad
* [ ] @eddiedialpad
* [ ] @egalpin
* [x] @jonathan-johnston
* [x] @kylepad
* [x] @shaundialpad