### PR TITLE
refactor(gcloud): gcf deploy from path & no default mem

### DIFF
--- a/gcloud/orb.yaml
+++ b/gcloud/orb.yaml
@@ -237,7 +237,7 @@ jobs:
         type: string
       packagename:
         description: >
-          Name of the package to be deployed to this cloud function. This package should be a .zip
+          Name of the package to be deployed to this cloud function.
         type: string
       project:
         description: >
@@ -247,6 +247,7 @@ jobs:
         default: small
         type: string
       memory:
+        default: ''
         description: >
           Limit on the amount of memory the function can use. Allowed values are: 128MB, 256MB, 512MB, 1024MB, and 2048MB.
         type: string
@@ -257,27 +258,25 @@ jobs:
       - run: apk add --no-cache --no-progress zip
       - checkout
       - run:
-          name: package function source as zip and upload to gcs
+          name: restructure files for target package
           command: |
             cd functions/
+            mkdir -p /tmp/build
             cp "./<<parameters.packagename>>/requirements.txt" requirements.txt
             cp "./<<parameters.packagename>>/mains/<<parameters.funcname>>.py" main.py
             sed -i "s/\${GEMFURY_TOKEN}/$GEMFURY_TOKEN/g" requirements.txt
-            zip -r "<<parameters.funcname>>.zip" "./<<parameters.packagename>>"/* main.py requirements.txt
-            gsutil cp "<<parameters.funcname>>.zip" "gs://<<parameters.project>>-cloud-function-zips/<<parameters.packagename>>/"
-
+            cp -R "./<<parameters.packagename>>" main.py requirements.txt /tmp/build
       - when:
           condition: <<parameters.memory>>
           steps:
             - run: |
                 gcloud functions deploy <<parameters.funcname>> --memory=<<parameters.memory>> \
-                  --source="gs://<<parameters.project>>-cloud-function-zips/<<parameters.packagename>>/<<parameters.funcname>>.zip"
+                  --source="/tmp/build"
       - unless:
           condition: <<parameters.memory>>
           steps:
             - run: |
-                gcloud functions deploy <<parameters.funcname>> \
-                  --source="gs://<<parameters.project>>-cloud-function-zips/<<parameters.packagename>>/<<parameters.funcname>>.zip"
+                gcloud functions deploy <<parameters.funcname>> --source="/tmp/build"
 
   deploy-cloud-run:
     description: >

--- a/gcloud/orb.yaml
+++ b/gcloud/orb.yaml
@@ -249,7 +249,6 @@ jobs:
       memory:
         description: >
           Limit on the amount of memory the function can use. Allowed values are: 128MB, 256MB, 512MB, 1024MB, and 2048MB.
-        default: 128MB
         type: string
     steps:
       - auth:
@@ -266,9 +265,19 @@ jobs:
             sed -i "s/\${GEMFURY_TOKEN}/$GEMFURY_TOKEN/g" requirements.txt
             zip -r "<<parameters.funcname>>.zip" "./<<parameters.packagename>>"/* main.py requirements.txt
             gsutil cp "<<parameters.funcname>>.zip" "gs://<<parameters.project>>-cloud-function-zips/<<parameters.packagename>>/"
-      - run: |
-          gcloud functions deploy <<parameters.funcname>> --memory=<<parameters.memory>> \
-            --source="gs://<<parameters.project>>-cloud-function-zips/<<parameters.packagename>>/<<parameters.funcname>>.zip"
+
+      - when:
+          condition: <<parameters.memory>>
+          steps:
+            - run: |
+                gcloud functions deploy <<parameters.funcname>> --memory=<<parameters.memory>> \
+                  --source="gs://<<parameters.project>>-cloud-function-zips/<<parameters.packagename>>/<<parameters.funcname>>.zip"
+      - unless:
+          condition: <<parameters.memory>>
+          steps:
+            - run: |
+                gcloud functions deploy <<parameters.funcname>> \
+                  --source="gs://<<parameters.project>>-cloud-function-zips/<<parameters.packagename>>/<<parameters.funcname>>.zip"
 
   deploy-cloud-run:
     description: >


### PR DESCRIPTION
## Summary
<!---
Summary of changes. Include any relevant context and complexities. Link any
relevant tickets / branches / other PRs / blockers / etc.
--->

Unset default memory on GCF deploy and upload from file path. These settings have interfered with required settings in Terraform (which is required for VPC connector, PubSub triggers) and caused the source of truth for GCFs to be split across more than one repo. This change addresses that by making the deploy operation simpler and change nothing about the GCF config.

---

One thing I don't like about this proposal is that this only accounts for memory as being the point of possible discrepancies between TF & CI. What if there are other parameters that come along that we add? Will this hidden dependency hit us again?

What if instead we have a "trigger-only" mode that explicitly does not update any of the other parameters? That would make it abundantly clear that it won't modify your function's settings. It would also make it clear in `tooling` that we are trying to avoid changing any settings.

### Checklist
<!---
See docs.talkiq-echelon.talkiq.com/static/docs/guides/pull-requests.html#guidelines

Feel free to add anything extra to the list if need be!
--->
- [x] My comments/docstrings/type hints are clear
- [ ] I've written new tests or this change does not need them
- [x] I've tested this manually
- [ ] The architecture diagrams have been updated, if need be
- [ ] I've included any special rollback strategies above
- [ ] Any relevant metrics/monitors/SLOs have been added or modified
- [x] I've notified all relevant stakeholders of the change
