### PR TITLE
chore(tester): pin default executor to docker-compose v1

### DIFF
--- a/tester/orb.yaml
+++ b/tester/orb.yaml
@@ -175,7 +175,7 @@ jobs:
           for the GCP project.
         type: env_var_name
       executor:
-        default: cimg/base:stable-20.04
+        default: cimg/base:2021.11-20.04
         description: >
           Name of the docker image to use to execute the job.
         type: string


### PR DESCRIPTION
## Summary
<!---
Summary of changes. Include any relevant context and complexities. Link any
relevant tickets / branches / other PRs / blockers / etc.
--->

CircleCI has decided to update the `cimg/base:stable-20.04` image with Docker Compose V2, which now is referenced by `docker compose` instead of `docker-compose`. This has broken our builds since we expected a "stable" image to remain stable. To maintain stability in `talkiq/tester` I am pinning the default executor to the latest compatible version (i.e. last month's image, which uses Docker Compose V1) and releasing a patch version of `talkiq/tester`. I will subsequently release a major version of `talkiq/tester` with references to Docker Compose as `docker compose` and the default executor as `cimg/base:stable-20.04`. This should fix any broken builds and allow users to upgrade to Docker Compose V2 at their leisure.

https://discuss.circleci.com/t/docker-compose-v2-now-in-cimg-base/42184

https://hub.docker.com/layers/cimg/base/2021.11-20.04/images/sha256-376c1dc2a8a549aa66c03ccd1c5efc8212e40b0d6138a1e465841a9dab8b1630?context=explore

### Checklist
<!---
See docs.talkiq-echelon.talkiq.com/static/docs/guides/pull-requests.html#guidelines

Feel free to add anything extra to the list if need be!
--->
- [ ] My comments/docstrings/type hints are clear
- [ ] I've written new tests or this change does not need them
- [ ] I've tested this manually
- [ ] The architecture diagrams have been updated, if need be
- [ ] I've included any special rollback strategies above
- [ ] Any relevant metrics/monitors/SLOs have been added or modified
- [ ] I've notified all relevant stakeholders of the change
