### PR TITLE
chore(tester): use docker compose v2 in stable cimg container

### DIFF
--- a/tester/orb.yaml
+++ b/tester/orb.yaml
@@ -137,7 +137,7 @@ jobs:
 
   docker-compose:
     description:
-      Runs docker-compose service
+      Runs Docker Compose service (V2)
     docker:
       - image: <<parameters.executor>>
         user: <<parameters.user>>
@@ -161,12 +161,12 @@ jobs:
       cwd:
         default: '.'
         description: >
-          Working directory used when running docker-compose commands.
+          Working directory used when running Docker Compose commands.
         type: string
       compose_args:
         default: '-f docker-compose.yaml'
         description: >
-          Docker-compose args such as a chain of files to use.
+          Docker Compose args such as a chain of files to use.
         type: string
       gcr_creds:
         default: GCLOUD_SERVICE_KEY
@@ -175,7 +175,7 @@ jobs:
           for the GCP project.
         type: env_var_name
       executor:
-        default: cimg/base:2021.11-20.04
+        default: cimg/base:stable-20.04
         description: >
           Name of the docker image to use to execute the job.
         type: string
@@ -195,7 +195,7 @@ jobs:
         type: string
       service_name:
         description: >
-          Name of docker-compose service to run
+          Name of Docker Compose service to run
         type: string
     steps:
       - when:
@@ -217,20 +217,20 @@ jobs:
       - run:
           working_directory: <<parameters.cwd>>
           # has to be built explicitly https://github.com/docker/compose/issues/7336
-          command: docker-compose <<parameters.compose_args>> build <<parameters.build_options>> <<parameters.service_name>> <<parameters.build>>
+          command: docker compose <<parameters.compose_args>> build <<parameters.build_options>> <<parameters.service_name>> <<parameters.build>>
           environment:
             DOCKER_BUILDKIT: 1
             COMPOSE_DOCKER_CLI_BUILD: 1
       - run:
           working_directory: <<parameters.cwd>>
-          command: docker-compose <<parameters.compose_args>> run --rm <<parameters.service_name>> <<parameters.args>>
+          command: docker compose <<parameters.compose_args>> run --rm <<parameters.service_name>> <<parameters.args>>
           environment:
-            # Workaround for docker-compose being unable to pull image from gcr
+            # Workaround for Docker Compose being unable to pull image from gcr
             # https://github.com/GoogleCloudPlatform/cloud-sdk-docker/issues/193#issuecomment-586288752
             LD_LIBRARY_PATH: /usr/local/lib
       - run:
           working_directory: <<parameters.cwd>>
-          command: docker-compose <<parameters.compose_args>> logs -t | sort -k 3
+          command: docker compose <<parameters.compose_args>> logs -t | sort -k 3
           when: on_fail
 
 orbs:


### PR DESCRIPTION
## Summary
<!---
Summary of changes. Include any relevant context and complexities. Link any
relevant tickets / branches / other PRs / blockers / etc.
--->

As a follow-up to https://github.com/talkiq/circleci-orbs/pull/75, we need to un-pin the `cimg/base` and use the `stable-*` image tag which uses Docker Compose V2 and an incompatible syntax: `s/docker-compose/docker compose/`. I believe that this warrants a release of a major version of `talkiq/tester` in order to keep up to date with `cimg/base` releases as well as having consistent default images that align with how we execute Docker Compose in our orb. I haven't checked yet whether the orb code itself should change but Compose V2 is supposed to be compatible with how V1 is used:

https://docs.docker.com/compose/cli-command/

Thoughts?

### Checklist
<!---
See docs.talkiq-echelon.talkiq.com/static/docs/guides/pull-requests.html#guidelines

Feel free to add anything extra to the list if need be!
--->
- [ ] My comments/docstrings/type hints are clear
- [ ] I've written new tests or this change does not need them
- [ ] I've tested this manually
- [ ] The architecture diagrams have been updated, if need be
- [ ] I've included any special rollback strategies above
- [ ] Any relevant metrics/monitors/SLOs have been added or modified
- [ ] I've notified all relevant stakeholders of the change
