### PR TITLE
leanaha/slack on failure

### DIFF
--- a/notifier/orb.yaml
+++ b/notifier/orb.yaml
@@ -36,7 +36,7 @@ commands:
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "Job Failed. :x:",
+                    "text": "Job Failed :x:",
                     "emoji": true
                   }
                 },

--- a/notifier/orb.yaml
+++ b/notifier/orb.yaml
@@ -33,12 +33,16 @@ commands:
               "text": "",
               "blocks": [
                 {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "Job Failed. :x:",
+                    "emoji": true
+                  }
+                },
+                {
                   "type": "section",
                   "fields": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Failure* :x:"
-                    },
                     {
                       "type": "mrkdwn",
                       "text": "Job name: `${CIRCLE_JOB}`"

--- a/notifier/orb.yaml
+++ b/notifier/orb.yaml
@@ -207,7 +207,7 @@ jobs:
                 }' \
             "https://sentry.io/api/0/organizations/<<parameters.organization>>/releases/"
 
-  slack:
+  slack-on-deploy:
     description: |
       Uses thekevjames/slack-notifier to send a deployment notification to your workspace.
     executor: alpine-stable

--- a/notifier/orb.yaml
+++ b/notifier/orb.yaml
@@ -15,8 +15,10 @@ executors:
 # - It MUST be used as a post-step from a job
 commands:
   slack-on-fail:
-    description: |
-      Uses slack orb to send messages to slack when a job fails. Note that if a job uses parallelism or matrix, it will send as many messages as jobs executed.
+    description: >
+      Uses slack orb to send messages to slack when a job fails.
+      Note that if a job uses parallelism or matrix, it will send as many
+      messages as jobs executed.
     parameters:
       channel:
         default: ${SLACK_DEFAULT_CHANNEL}
@@ -53,7 +55,7 @@ commands:
                       "type": "mrkdwn",
                       "text": "Blame :point_right: @${CIRCLE_USERNAME}"
                     }
-                  ],
+                  ]
                 },
                 {
                   "type": "actions",

--- a/notifier/orb.yaml
+++ b/notifier/orb.yaml
@@ -11,7 +11,7 @@ executors:
     resource_class: small
 
 commands:
-  slack-on-failure:
+  slack-on-deploy:
     description: |
       Uses slack orb to send a notification to slack when a deployment fails.
     parameters:
@@ -31,7 +31,7 @@ commands:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":alert: *Failure* :alert: \n - Job name: `${CIRCLE_JOB}` \n - Repository name: `${CIRCLE_PROJECT_REPONAME}` \n - Branch `${CIRCLE_BRANCH}` \n - Blame :point_right: `@${CIRCLE_USERNAME}` \n - Build number: #${CIRCLE_BUILD_NUM}"
+                    "text": "*Failure* :x: \n - Job name: `${CIRCLE_JOB}` \n - Repository name: `${CIRCLE_PROJECT_REPONAME}` \n - Branch `${CIRCLE_BRANCH}` \n - Blame :point_right: @${CIRCLE_USERNAME} \n - Build number: #${CIRCLE_BUILD_NUM}"
                   }
                 },
                 {

--- a/notifier/orb.yaml
+++ b/notifier/orb.yaml
@@ -243,6 +243,3 @@ jobs:
               ]
             }
           event: fail
-
-
-

--- a/notifier/orb.yaml
+++ b/notifier/orb.yaml
@@ -203,11 +203,6 @@ jobs:
       Uses slack orb to send a notification to slack when a deployment fails.
     executor: alpine-stable
     parameters:
-      changes:
-        default: ''
-        description: |
-          The (optional) changelog for this release.
-        type: string
       channel:
         default: ${SLACK_DEFAULT_CHANNEL}
         description: |

--- a/notifier/orb.yaml
+++ b/notifier/orb.yaml
@@ -2,7 +2,7 @@ version: 2.1
 description: "Tools for notifying external services about CI events"
 
 orbs:
-  slack: circleci/slack@4.7.0
+  slack: circleci/slack@4
 
 executors:
   alpine-stable:
@@ -10,10 +10,13 @@ executors:
     - image: alpine:latest
     resource_class: small
 
+# This command has two conditions:
+# - Since it could be too noisy, it MUST be used only on production deploys!
+# - It MUST be used as a post-step from a job
 commands:
-  slack-on-deploy:
+  slack-on-fail:
     description: |
-      Uses slack orb to send a notification to slack when a deployment fails.
+      Uses slack orb to send messages to slack when a job fails. Note that if a job uses parallelism or matrix, it will send as many messages as jobs executed.
     parameters:
       channel:
         default: ${SLACK_DEFAULT_CHANNEL}
@@ -29,10 +32,28 @@ commands:
               "blocks": [
                 {
                   "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*Failure* :x: \n - Job name: `${CIRCLE_JOB}` \n - Repository name: `${CIRCLE_PROJECT_REPONAME}` \n - Branch `${CIRCLE_BRANCH}` \n - Blame :point_right: @${CIRCLE_USERNAME} \n - Build number: #${CIRCLE_BUILD_NUM}"
-                  }
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Failure* :x:"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "Job name: `${CIRCLE_JOB}`"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "Repository name: `${CIRCLE_PROJECT_REPONAME}`"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "Branch `${CIRCLE_BRANCH}`"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "Blame :point_right: @${CIRCLE_USERNAME}"
+                    }
+                  ],
                 },
                 {
                   "type": "actions",

--- a/notifier/orb.yaml
+++ b/notifier/orb.yaml
@@ -10,6 +10,48 @@ executors:
     - image: alpine:latest
     resource_class: small
 
+commands:
+  slack-on-failure:
+    description: |
+      Uses slack orb to send a notification to slack when a deployment fails.
+    executor: alpine-stable
+    parameters:
+      channel:
+        default: ${SLACK_DEFAULT_CHANNEL}
+        description: |
+          Destination channel for your slack messages.
+        type: string
+    steps:
+      - slack/notify:
+          channel: <<parameters.channel>>
+          custom: |
+            {
+              "text": "",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":alert: *Failure* :alert: \n - Job name: `${CIRCLE_JOB}` \n - Repository name: `${CIRCLE_PROJECT_REPONAME}` \n - Branch `${CIRCLE_BRANCH}` \n - Blame :point_right: `@${CIRCLE_USERNAME}` \n - Build number: #${CIRCLE_BUILD_NUM}"
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View Job"
+                      },
+                      "url": "${CIRCLE_BUILD_URL}"
+                    }
+                  ]
+                }
+              ]
+            }
+          event: fail
+
 jobs:
   datadog:
     description: |
@@ -197,44 +239,3 @@ jobs:
             -u "<<parameters.user>>" \
             -v "<<parameters.version>>" \
             -w "<<parameters.webhook>>"
-
-  slack-on-failure:
-    description: |
-      Uses slack orb to send a notification to slack when a deployment fails.
-    executor: alpine-stable
-    parameters:
-      channel:
-        default: ${SLACK_DEFAULT_CHANNEL}
-        description: |
-          Destination channel for your slack messages.
-        type: string
-    steps:
-      - slack/notify:
-          channel: <<parameters.channel>>
-          custom: |
-            {
-              "text": "",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":alert: *Failure* :alert: \n - Job name: `${CIRCLE_JOB}` \n - Repository name: `${CIRCLE_PROJECT_REPONAME}` \n - Branch `${CIRCLE_BRANCH}` \n - Blame :point_right: `@${CIRCLE_USERNAME}` \n - Build number: #${CIRCLE_BUILD_NUM}"
-                  }
-                },
-                {
-                  "type": "actions",
-                  "elements": [
-                    {
-                      "type": "button",
-                      "text": {
-                        "type": "plain_text",
-                        "text": "View Job"
-                      },
-                      "url": "${CIRCLE_BUILD_URL}"
-                    }
-                  ]
-                }
-              ]
-            }
-          event: fail

--- a/notifier/orb.yaml
+++ b/notifier/orb.yaml
@@ -1,6 +1,9 @@
 version: 2.1
 description: "Tools for notifying external services about CI events"
 
+orbs:
+  slack: circleci/slack@4.7.0
+
 executors:
   alpine-stable:
     docker:
@@ -194,3 +197,52 @@ jobs:
             -u "<<parameters.user>>" \
             -v "<<parameters.version>>" \
             -w "<<parameters.webhook>>"
+
+  slack-on-failure:
+    description: |
+      Uses slack orb to send a notification to slack when a deployment fails.
+    executor: alpine-stable
+    parameters:
+      changes:
+        default: ''
+        description: |
+          The (optional) changelog for this release.
+        type: string
+      channel:
+        default: ${SLACK_DEFAULT_CHANNEL}
+        description: |
+          Destination channel for your slack messages.
+        type: string
+    steps:
+      - slack/notify:
+          channel: <<parameters.channel>>
+          custom: |
+            {
+              "text": "",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":alert: *Failure* :alert: \n - Job name: `${CIRCLE_JOB}` \n - Repository name: `${CIRCLE_PROJECT_REPONAME}` \n - Branch `${CIRCLE_BRANCH}` \n - Blame :point_right: `@${CIRCLE_USERNAME}` \n - Build number: #${CIRCLE_BUILD_NUM}"
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View Job"
+                      },
+                      "url": "${CIRCLE_BUILD_URL}"
+                    }
+                  ]
+                }
+              ]
+            }
+          event: fail
+
+
+

--- a/notifier/orb.yaml
+++ b/notifier/orb.yaml
@@ -14,7 +14,6 @@ commands:
   slack-on-failure:
     description: |
       Uses slack orb to send a notification to slack when a deployment fails.
-    executor: alpine-stable
     parameters:
       channel:
         default: ${SLACK_DEFAULT_CHANNEL}


### PR DESCRIPTION
## Summary
This PR adds a command to our notifier orb. It has to be added as a post-step from a job. If the job fails, this command sends a message to a channel in slack that can be defined with a parameter.

### Checklist
<!---
See docs.talkiq-echelon.talkiq.com/static/docs/guides/pull-requests.html#guidelines

Feel free to add anything extra to the list if need be!
--->
- [ ] My comments/docstrings/type hints are clear
- [ ] I've written new tests or this change does not need them
- [ ] I've tested this manually
- [ ] The architecture diagrams have been updated, if need be
- [ ] I've included any special rollback strategies above
- [ ] Any relevant metrics/monitors/SLOs have been added or modified
- [ ] I've notified all relevant stakeholders of the change
- [ ] I've updated .github/CODEOWNERS, if relevant
