### PR TITLE
fix(ci_notification): adding curl installation before sending slack notification

### DIFF
--- a/notifier/orb.yaml
+++ b/notifier/orb.yaml
@@ -26,6 +26,18 @@ commands:
           Destination channel for your slack messages.
         type: string
     steps:
+      - run:
+          name: install curl
+          command: |
+            if which apk >/dev/null; then
+              apk add --no-cache --no-progress curl curl-dev
+            elif which apt-get >/dev/null; then
+              apt-get update -qy
+              apt-get install -qy curl
+            else
+              echo >&2 "ERROR: could not find supported package manager"
+              exit 1
+            fi
       - slack/notify:
           channel: <<parameters.channel>>
           custom: |


### PR DESCRIPTION
## Summary
I added a step inside the command `slack-on-fail` to install `curl`. We need it because otherwise, we will not send slack notifications when `curl` is not installed.

### Checklist
<!---
See docs.talkiq-echelon.talkiq.com/static/docs/guides/pull-requests.html#guidelines

Feel free to add anything extra to the list if need be!
--->
- [ ] My comments/docstrings/type hints are clear
- [ ] I've written new tests or this change does not need them
- [ ] I've tested this manually
- [ ] The architecture diagrams have been updated, if need be
- [ ] I've included any special rollback strategies above
- [ ] Any relevant metrics/monitors/SLOs have been added or modified
- [ ] I've notified all relevant stakeholders of the change
- [ ] I've updated .github/CODEOWNERS, if relevant
