### PR TITLE
feat(docs,linter,tester): use python:latest be default

### DIFF
--- a/docs/orb.yaml
+++ b/docs/orb.yaml
@@ -18,7 +18,7 @@ jobs:
           for the GCP project.
         type: env_var_name
       executor:
-        default: python:3.7.9
+        default: python:latest
         description: >
           Name of the docker image to use to execute the job. Must have python3
           installed.

--- a/linter/orb.yaml
+++ b/linter/orb.yaml
@@ -61,7 +61,7 @@ jobs:
           Optional alternate config file.
         type: string
       python_version:
-        default: 3.7.8
+        default: latest
         description: |
           The python version used to run pre-commit.
         type: string

--- a/tester/orb.yaml
+++ b/tester/orb.yaml
@@ -31,7 +31,7 @@ jobs:
           Arguments to `pip install` command.
         type: string
       python_version:
-        default: 3.7.8
+        default: latest
         description: |
           The python version used to run pytest.
         type: string
@@ -100,7 +100,7 @@ jobs:
           Arguments to `pip install` command.
         type: string
       python_version:
-        default: 3.7.8
+        default: latest
         description: |
           The python version used to run pytest.
         type: string


### PR DESCRIPTION
## Summary
This feels like the only "reasonable" default; previously we've had some
scattered defaults, mostly in the py3.7.x range, but any cases where
users do not want the most up-to-date base image should probably be
places where the user specifies that version anyway.

Breaking change to the relevant orbs as we're changing a default.

### Checklist
- [x] My comments/docstrings/type hints are clear
- [x] I've written new tests or this change does not need them
- [x] I've tested this manually
- [x] The architecture diagrams have been updated, if need be
- [x] I've included any special rollback strategies above
- [x] Any relevant metrics/monitors/SLOs have been added or modified
- [x] I've notified all relevant stakeholders of the change
- [x] I've updated .github/CODEOWNERS, if relevant