### PR TITLE
fix(poetry): install poetry via curl

### DIFF
--- a/poetry/orb.yaml
+++ b/poetry/orb.yaml
@@ -1,6 +1,27 @@
 version: 2.1
 description: "Tools for running poetry commands."
 
+commands:
+  install:
+    description: >
+      Install poetry. Requires a pre-existing Python 3.x installation.
+      Currently supported package managers: apk, apt-get.
+    steps:
+      - run:
+          name: install curl
+          command: |
+            if which apk >/dev/null; then
+              apk add --no-cache --no-progress curl
+            elif which apt-get >/dev/null; then
+              apt-get update -qy
+              apt-get install -qy curl
+            else
+              echo >&2 "ERROR: could not find supported package manager"
+              exit 1
+            fi
+      - run: curl -sSL https://install.python-poetry.org | python3
+      - run: echo 'export PATH="/root/.local/bin:${PATH}"' >> ${BASH_ENV}
+
 jobs:
   run:
     description: >
@@ -39,7 +60,7 @@ jobs:
         default: small
         type: string
     steps:
-      - run: python3 -m pip install poetry
+      - install
       - steps: <<parameters.configure_poetry>>
       - checkout
       - run:
@@ -100,7 +121,7 @@ jobs:
         type: boolean
         default: true
     steps:
-      - run: python3 -m pip install poetry
+      - install
       - checkout
       - run:
           name: validate tag matches pyproject.toml

--- a/poetry/orb.yaml
+++ b/poetry/orb.yaml
@@ -6,6 +6,18 @@ commands:
     description: >
       Install poetry. Requires a pre-existing Python 3.x installation.
       Currently supported package managers: apk, apt-get.
+    parameters:
+      allow_preview:
+        default: false
+        description: >
+          Allow prerelease versions of Poetry to be installed.
+        type: boolean
+      version:
+        default: latest
+        description: >
+          Specify the version of poetry to install. Must be either an "x.y.z"
+          version or "latest".
+        type: string
     steps:
       - run:
           name: install curl
@@ -19,6 +31,15 @@ commands:
               echo >&2 "ERROR: could not find supported package manager"
               exit 1
             fi
+      - unless:
+          condition:
+            equal: [ <<parameters.version>>, "latest" ]
+          steps:
+            - run: echo "export POETRY_VERSION=<<parameters.version>>" >> ${BASH_ENV}
+      - when:
+          condition: <<parameters.allow_preview>>
+          steps:
+            - run: echo "export POETRY_PREVIEW=1" >> ${BASH_ENV}
       - run: curl -sSL https://install.python-poetry.org | python3
       - run: echo 'export PATH="/root/.local/bin:${PATH}"' >> ${BASH_ENV}
 


### PR DESCRIPTION
## Summary
Part of the myriad and ongoing efforts to move away from installing poetry via
pip. Also exposes a `poetry/install` command which may be of use elsewhere
downstream.

### Checklist
- [x] My comments/docstrings/type hints are clear
- [x] I've written new tests or this change does not need them
- [x] I've tested this manually
- [x] The architecture diagrams have been updated, if need be
- [x] I've included any special rollback strategies above
- [x] Any relevant metrics/monitors/SLOs have been added or modified
- [x] I've notified all relevant stakeholders of the change
  - @allandialpad this might be useful to you for your realtime-dev PR
- [x] I've updated .github/CODEOWNERS, if relevant