### PR TITLE
Upgrade docker build to buildx

### DIFF
--- a/docker/orb.yaml
+++ b/docker/orb.yaml
@@ -44,14 +44,12 @@ commands:
       - run:
           name: docker build
           command: |
-            docker build \
+            docker buildx build \
               <<parameters.build_args>> \
               --progress=plain \
               -f <<parameters.path>>/<<parameters.dockerfile>> \
               -t <<parameters.local_image_name>> \
               <<parameters.path>>
-          environment:
-            DOCKER_BUILDKIT: 1
 
   tag:
     description: >


### PR DESCRIPTION
## Summary
<!---
Summary of changes. Include any relevant context and complexities. Link any
relevant tickets / branches / other PRs / blockers / etc.
--->
Update to use `docker buildx build` instead of `docker build`

### Checklist
<!---
See docs.talkiq-echelon.talkiq.com/static/docs/guides/pull-requests.html#guidelines

Feel free to add anything extra to the list if need be!
--->
- [ ] My comments/docstrings/type hints are clear
- [ ] I've written new tests or this change does not need them
- [ ] I've tested this manually
- [ ] The architecture diagrams have been updated, if need be
- [ ] I've included any special rollback strategies above
- [ ] Any relevant metrics/monitors/SLOs have been added or modified
- [ ] I've notified all relevant stakeholders of the change
- [ ] I've updated .github/CODEOWNERS, if relevant
