### PR TITLE
feat: allow executor overrides in all orbs

### DIFF
--- a/deployer/orb.yaml
+++ b/deployer/orb.yaml
@@ -1,33 +1,37 @@
 version: 2.1
 description: "Tools for running deployment commands"
 
+executors:
+  python-latest:
+    docker:
+      - image: python:latest
+    resource_class: small
+
 jobs:
   gemfury:
     description: >
       Deploy a package to Gemfury (ie. for internal usage only). Use PyPI for
       OSS projects!
-    docker:
-      - image: python:<<parameters.python_version>>
-    resource_class: <<parameters.resource_class>>
+    executor: <<parameters.executor>>
     parameters:
       folder:
         default: '.'
         description: >
           Path to the folder containing the Python package.
         type: string
+      executor:
+        default: python-latest
+        description: >
+          Executor for the job. Must have a working Python version installed.
+          To use your own custom executor, see
+          `https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-executors`.
+          Defaults to a small python:latest docker image.
+        type: executor
       gemfury_token:
         default: GEMFURY_TOKEN
         description: >
           Name of the env var containing the Gemfury token.
         type: env_var_name
-      python_version:
-        description: >
-          Python version to use to build and deploy the package. Used as the
-          docker executor, so you can use any sort of tag (eg. ``3.7.4-slim``).
-        type: string
-      resource_class:
-        default: small
-        type: string
       verify_version:
         default: ${CIRCLE_TAG}
         description: >

--- a/docker/orb.yaml
+++ b/docker/orb.yaml
@@ -1,6 +1,12 @@
 version: 2.1
 description: "Tools for running docker commands."
 
+executors:
+  docker-latest:
+    docker:
+      - image: docker:git
+    resource_class: medium
+
 commands:
   build:
     description: >
@@ -368,9 +374,7 @@ jobs:
       Build, tag, and push a docker image. It will be tagged with all relevant
       metadata, eg. commit hash, branch (if this is a branch build), tag (if
       this is a tag build), and "latest".
-    docker:
-      - image: <<parameters.executor>>
-    resource_class: <<parameters.resource_class>>
+    executor: <<parameters.executor>>
     parameters:
       build_args:
         default: ''
@@ -383,10 +387,13 @@ jobs:
           Name of dockerfile to use.
         type: string
       executor:
-        default: docker:20.10.6-git
+        default: docker-latest
         description: >
-          Name of the docker image to use to execute the job.
-        type: string
+          Executor for the job. Must support docker-in-docker and have a
+          working git command installed. To use your own custom executor, see
+          `https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-executors`.
+          Defaults to a medium docker:git docker image.
+        type: executor
       image:
         default: ${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
         description: >
@@ -404,9 +411,6 @@ jobs:
         default: 'docker.io'
         description: >
           Container registry to-be-used.
-        type: string
-      resource_class:
-        default: medium
         type: string
       workspace:
         default: ''

--- a/docs/orb.yaml
+++ b/docs/orb.yaml
@@ -1,15 +1,19 @@
 version: 2.1
 description: "Tools for running documentation commands"
 
+executors:
+  python-latest:
+    docker:
+      - image: python:latest
+    resource_class: small
+
 jobs:
   compile-and-upload:
     description: >
       Compiles Sphinxdocs for a repository, then deploy it to Google Storage
       (ie. for internal use only). Optional hooks are provided for building
       APIdocs, etc.
-    docker:
-      - image: <<parameters.executor>>
-    resource_class: <<parameters.resource_class>>
+    executor: <<parameters.executor>>
     parameters:
       creds:
         default: GCLOUD_SERVICE_KEY
@@ -18,11 +22,13 @@ jobs:
           for the GCP project.
         type: env_var_name
       executor:
-        default: python:latest
+        default: python-latest
         description: >
-          Name of the docker image to use to execute the job. Must have python3
-          installed.
-        type: string
+          Executor for the job. Must have a working Python version installed.
+          To use your own custom executor, see
+          `https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-executors`.
+          Defaults to a small python:latest docker image.
+        type: executor
       folder:
         default: '.'
         description: >
@@ -77,9 +83,6 @@ jobs:
         default: ${CIRCLE_PROJECT_REPONAME}
         description: |
           The name of the project folder in GCS.
-        type: string
-      resource_class:
-        default: small
         type: string
     steps:
       - run: python3 -m pip install sphinx

--- a/gcloud/orb.yaml
+++ b/gcloud/orb.yaml
@@ -1,6 +1,16 @@
 version: 2.1
 description: "Tools for running gcloud commands."
 
+executors:
+  docker-latest:
+    docker:
+      - image: docker:git
+    resource_class: medium
+  gcloud-alpine-latest:
+    docker:
+      - image: google/cloud-sdk:alpine
+    resource_class: small
+
 commands:
   auth:
     description: >
@@ -253,9 +263,7 @@ jobs:
   deploy-cloud-function:
     description: >
       Deploy a package to Google's Cloud Function service.
-    docker:
-      - image: google/cloud-sdk:alpine
-    resource_class: <<parameters.resource_class>>
+    executor: <<parameters.executor>>
     parameters:
       creds:
         default: GCLOUD_SERVICE_KEY
@@ -263,9 +271,23 @@ jobs:
           Name of environment variable storing the base64-encoded service key
           for the GCP project.
         type: env_var_name
+      executor:
+        default: gcloud-alpine-latest
+        description: >
+          Executor for the job. Must be alpine-based and have a working gcloud
+          version installed. To use your own custom executor, see
+          `https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-executors`.
+          Defaults to a small google/cloud-sdk:alpine docker image.
+        type: executor
       funcname:
         description: >
           Name of the cloud function being deployed.
+        type: string
+      memory:
+        default: ''
+        description: >
+          Limit on the amount of memory the function can use. Allowed values
+          are: 128MB, 256MB, 512MB, 1024MB, and 2048MB.
         type: string
       packagename:
         description: >
@@ -274,14 +296,6 @@ jobs:
       project:
         description: >
           Name of GCP project to which we will push.
-        type: string
-      resource_class:
-        default: small
-        type: string
-      memory:
-        default: ''
-        description: >
-          Limit on the amount of memory the function can use. Allowed values are: 128MB, 256MB, 512MB, 1024MB, and 2048MB.
         type: string
     steps:
       - run: apk add --no-cache --no-progress py3-pip zip
@@ -322,9 +336,7 @@ jobs:
     description: >
       Deploy a container to either Google's managed Cloud Run service or to a
       specified Knative cluster.
-    docker:
-      - image: google/cloud-sdk:alpine
-    resource_class: <<parameters.resource_class>>
+    executor: <<parameters.executor>>
     parameters:
       creds:
         default: GCLOUD_SERVICE_KEY
@@ -354,6 +366,14 @@ jobs:
         description: >
           Evironment variables to be passed into the cloud run container.
         type: string
+      executor:
+        default: gcloud-alpine-latest
+        description: >
+          Executor for the job. Must have a working gcloud version installed.
+          To use your own custom executor, see
+          `https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-executors`.
+          Defaults to a small google/cloud-sdk:alpine docker image.
+        type: executor
       image:
         default: ${CIRCLE_PROJECT_REPONAME}
         description: >
@@ -380,9 +400,6 @@ jobs:
       region:
         description: >
           Name of GCP region to which we will push.
-        type: string
-      resource_class:
-        default: small
         type: string
     steps:
       - auth:
@@ -433,8 +450,7 @@ jobs:
     description: >
       Deploy a k8s deployment to GKE via provided YAML. Will record the
       previous deployment version in a workspace.
-    docker:
-      - image: google/cloud-sdk:alpine
+    executor: <<parameters.executor>>
     parameters:
       cluster:
         type: string
@@ -445,6 +461,14 @@ jobs:
           Name of your deployment. If you are using multi-deployment
           autoscaling this may correspond to multiple actual k8s deployments.
         type: string
+      executor:
+        default: gcloud-alpine-latest
+        description: >
+          Executor for the job. Must have a working gcloud version installed.
+          To use your own custom executor, see
+          `https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-executors`.
+          Defaults to a small google/cloud-sdk:alpine docker image.
+        type: executor
       k8s_yaml:
         description: >
           The k8s YAML file for your deployment(s).
@@ -518,20 +542,12 @@ jobs:
       This job will build, tag, and push a docker image. It will be tagged with
       all relevant metadata, eg. commit hash, branch (if this is a branch
       build), tag (if this is a tag build), and "latest".
-    docker:
-      - image: <<parameters.executor>>
-    resource_class: <<parameters.resource_class>>
+    executor: <<parameters.executor>>
     parameters:
       build_args:
         default: ''
         description: >
           Extra flags to pass to docker build.
-        type: string
-      git_repository_url:
-        default: ''
-        description: >
-          If unset, uses the current repository. Otherwise, clones the provided
-          repo's default branch to a depth of 1.
         type: string
       creds:
         default: GCLOUD_SERVICE_KEY
@@ -551,9 +567,18 @@ jobs:
           Name of dockerfile to use.
         type: string
       executor:
-        default: docker:20.10.6-git
+        default: docker-latest
         description: >
-          Name of the docker image to use to execute the job.
+          Executor for the job. Must support docker-in-docker and have a
+          working git command installed. To use your own custom executor, see
+          `https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-executors`.
+          Defaults to a medium docker:git docker image.
+        type: executor
+      git_repository_url:
+        default: ''
+        description: >
+          If unset, uses the current repository. Otherwise, clones the provided
+          repo's default branch to a depth of 1.
         type: string
       image:
         default: ${CIRCLE_PROJECT_REPONAME}
@@ -576,9 +601,6 @@ jobs:
         default: 'gcr.io'
         description: >
           Container registry to-be-used.
-        type: string
-      resource_class:
-        default: medium
         type: string
       workspace:
         default: ''

--- a/gcloud/orb.yaml
+++ b/gcloud/orb.yaml
@@ -48,18 +48,17 @@ commands:
           If enabled, turns on CircleCI's docker_layer_caching which makes
           builds faster by skipping steps that have not changed.
         type: boolean
+      version:
+        default: 20.10.6
+        description: >
+          The docker server version to be provisioned. See the docs for
+          available versions:
+          https://circleci.com/docs/2.0/building-docker-images/#docker-version
+        type: string
     steps:
-      - when:
-          condition: <<parameters.docker_layer_caching>>
-          steps:
-            - setup_remote_docker:
-                version: 20.10.6
-                docker_layer_caching: true
-      - unless:
-          condition: <<parameters.docker_layer_caching>>
-          steps:
-            - setup_remote_docker:
-                version: 20.10.6
+      - setup_remote_docker:
+          version: <<parameters.version>>
+          docker_layer_caching: <<parameters.docker_layer_caching>>
       - run: gcloud auth configure-docker --quiet
 
   configure-gke:

--- a/linter/orb.yaml
+++ b/linter/orb.yaml
@@ -1,6 +1,12 @@
 version: 2.1
 description: "Tools for running lint commands"
 
+executors:
+  python-latest:
+    docker:
+      - image: python:latest
+    resource_class: small
+
 commands:
   pre-commit:
     description: |
@@ -8,17 +14,18 @@ commands:
     parameters:
       cache_prefix:
         default: ''
-        description: |
-          Optional cache prefix to be used on CircleCI. Can be used for cache busting or to ensure multiple jobs use different caches.
+        description: >
+          Optional cache prefix to be used on CircleCI. Can be used for cache
+          busting or to ensure multiple jobs use different caches.
         type: string
       config_file:
         default: '.pre-commit-config.yaml'
-        description: |
+        description: >
           Optional alternate config file.
         type: string
       version:
         default: latest
-        description: |
+        description: >
           Pre-commit package version.
         type: string
     steps:
@@ -47,30 +54,27 @@ jobs:
   pre-commit:
     description: |
       Runs pre-commit hooks against the current repo.
-    docker:
-      - image: python:<<parameters.python_version>>
-    resource_class: <<parameters.resource_class>>
+    executor: <<parameters.executor>>
     parameters:
       config_file:
         default: '.pre-commit-config.yaml'
-        description: |
+        description: >
           Optional alternate config file.
         type: string
-      python_version:
-        default: latest
-        description: |
-          The python version used to run pre-commit.
-        type: string
+      executor:
+        default: python-latest
+        description: >
+          Executor for the job. Must have a working Python version installed.
+          To use your own custom executor, see
+          `https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-executors`.
+          Defaults to a small python:latest docker image.
+        type: executor
       pre_commit_version:
         default: latest
-        description: |
+        description: >
           Pre-commit package version.
-        type: string
-      resource_class:
-        default: small
         type: string
     steps:
       - pre-commit:
-          cache_prefix: <<parameters.python_version>>
           config_file: <<parameters.config_file>>
           version: <<parameters.pre_commit_version>>

--- a/notifier/orb.yaml
+++ b/notifier/orb.yaml
@@ -7,7 +7,7 @@ orbs:
 executors:
   alpine-stable:
     docker:
-    - image: alpine:latest
+      - image: alpine:latest
     resource_class: small
 
 # This command has two conditions:
@@ -94,7 +94,7 @@ jobs:
   datadog:
     description: |
       Creates a datadog event.
-    executor: alpine-stable
+    executor: <<parameters.executor>>
     parameters:
       api_key:
         default: DATADOG_API_KEY
@@ -106,6 +106,14 @@ jobs:
         description: |
           Domain name of the Datadog ingestion API.
         type: string
+      executor:
+        default: alpine-latest
+        description: >
+          Executor for the job. Must be alpine-based. To use your own custom
+          executor, see
+          `https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-executors`.
+          Defaults to a small alpine:latest docker image.
+        type: executor
       tag:
         default: ""
         description: |
@@ -130,13 +138,21 @@ jobs:
   sentry-deployment:
     description: |
       Creates a new release deployment in Sentry. Should be run after the release has been created.
-    executor: alpine-stable
+    executor: <<parameters.executor>>
     parameters:
       environment:
         default: ${CIRCLE_TAG}
         description: |
           The environment for which the release applies.
         type: string
+      executor:
+        default: alpine-latest
+        description: >
+          Executor for the job. Must be alpine-based. To use your own custom
+          executor, see
+          `https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-executors`.
+          Defaults to a small alpine:latest docker image.
+        type: executor
       organization:
         default: ${CIRCLE_PROJECT_USERNAME}
         description: |
@@ -164,13 +180,21 @@ jobs:
   sentry-release:
     description: |
       Creates a new release in Sentry.
-    executor: alpine-stable
+    executor: <<parameters.executor>>
     parameters:
       commit:
         default: ${CIRCLE_SHA1}
         description: |
           The git commit SHA for the new release.
         type: string
+      executor:
+        default: alpine-latest
+        description: >
+          Executor for the job. Must be alpine-based. To use your own custom
+          executor, see
+          `https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-executors`.
+          Defaults to a small alpine:latest docker image.
+        type: executor
       prev_commit:
         default: ''
         description: |
@@ -222,7 +246,7 @@ jobs:
   slack-on-deploy:
     description: |
       Uses thekevjames/slack-notifier to send a deployment notification to your workspace.
-    executor: alpine-stable
+    executor: <<parameters.executor>>
     parameters:
       changes:
         default: ''
@@ -239,6 +263,14 @@ jobs:
         description: |
           The environment being deployed.
         type: string
+      executor:
+        default: alpine-latest
+        description: >
+          Executor for the job. Must be alpine-based. To use your own custom
+          executor, see
+          `https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-executors`.
+          Defaults to a small alpine:latest docker image.
+        type: executor
       prev_version:
         default: unknown
         description: |


### PR DESCRIPTION
## Summary
#86 was incredibly useful for allowing us to override executors rather than
copy-pasting a bunch of jobs. Executors are also supported by Renovate, which
means we caught some accidental usages of outdated images.

Apply those changes to everything!

* deployer, docker, docs, gcloud, linter: make the above change. BREAKING.
* notifier: make the above change. Not breaking.
* gcloud: additionally allow the docker server version to be specified.

### Checklist
- [x] My comments/docstrings/type hints are clear
- [x] I've written new tests or this change does not need them
- [x] I've tested this manually
- [x] The architecture diagrams have been updated, if need be
- [x] I've included any special rollback strategies above
- [x] Any relevant metrics/monitors/SLOs have been added or modified
- [x] I've notified all relevant stakeholders of the change
- [x] I've updated .github/CODEOWNERS, if relevant