### PR TITLE
Leanaha/run poetry with extras

### DIFF
--- a/poetry/orb.yaml
+++ b/poetry/orb.yaml
@@ -44,13 +44,13 @@ commands:
       - run: echo 'export PATH="/root/.local/bin:${PATH}"' >> ${BASH_ENV}
 
 jobs:
-  run: &run
+  run:
     description: >
       Run an arbitrary command within your poetry environment.
     docker:
       - image: python:<<parameters.python_version>>
     resource_class: <<parameters.resource_class>>
-    parameters:
+    parameters: &run-parameters
       cmd:
         type: string
       configure_poetry:
@@ -92,11 +92,14 @@ jobs:
           working_directory: <<parameters.cwd>>
 
   run_with_extra:
-    <<: *run
     description: >
       Run an arbitrary command within your poetry
       environment with extras (-E flag)
+    docker:
+      - image: python:<<parameters.python_version>>
+    resource_class: <<parameters.resource_class>>
     parameters:
+      <<: *run-parameters
       extra:
         type: string
     steps:

--- a/poetry/orb.yaml
+++ b/poetry/orb.yaml
@@ -101,9 +101,7 @@ jobs:
     description: >
       Run an arbitrary command within your poetry
       environment with extras (-E flag)
-    docker:
-      - image: python:<<parameters.python_version>>
-    resource_class: <<parameters.resource_class>>
+    executor: <<parameters.executor>>
     parameters:
       <<: *run-parameters
       extra:

--- a/poetry/orb.yaml
+++ b/poetry/orb.yaml
@@ -105,6 +105,7 @@ jobs:
     steps:
       - install
       - steps: <<parameters.configure_poetry>>
+      - checkout
       - run:
           command: poetry install -n --no-ansi -E <<parameters.extra>>
           working_directory: <<parameters.cwd>>

--- a/poetry/orb.yaml
+++ b/poetry/orb.yaml
@@ -107,7 +107,7 @@ jobs:
       - steps: <<parameters.configure_poetry>>
       - checkout
       - run:
-          command: poetry install -n --no-ansi -E <<parameters.extra>>
+          command: poetry install -n --no-ansi -E "<<parameters.extra>>"
           working_directory: <<parameters.cwd>>
       - run:
           command: poetry run <<parameters.cmd>>

--- a/poetry/orb.yaml
+++ b/poetry/orb.yaml
@@ -86,37 +86,30 @@ jobs:
           `https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-executors`.
           Defaults to a small python:latest docker image.
         type: executor
-    steps:
-      - install
-      - steps: <<parameters.configure_poetry>>
-      - checkout
-      - run:
-          command: poetry install -n --no-ansi
-          working_directory: <<parameters.cwd>>
-      - run:
-          command: poetry run <<parameters.cmd>>
-          working_directory: <<parameters.cwd>>
-
-  run-with-extra:
-    description: >
-      Run an arbitrary command within your poetry
-      environment with extras (-E flag)
-    executor: <<parameters.executor>>
-    parameters:
-      <<: *run-parameters
       extra:
+        description: >
+          Extra value to run with -E flag.
         type: string
+        default: ''
     steps:
       - install
       - steps: <<parameters.configure_poetry>>
       - checkout
-      - run:
-          command: poetry install -n --no-ansi -E "<<parameters.extra>>"
-          working_directory: <<parameters.cwd>>
+      - when:
+          condition: <<parameters.extra>>
+          steps:
+            - run:
+                command: poetry install -n --no-ansi -E "<<parameters.extra>> "
+                working_directory: <<parameters.cwd>>
+      - unless:
+          condition: <<parameters.extra>>
+          steps:
+            - run:
+                command: poetry install -n --no-ansi
+                working_directory: <<parameters.cwd>>
       - run:
           command: poetry run <<parameters.cmd>>
           working_directory: <<parameters.cwd>>
-
 
   publish:
     description: >

--- a/poetry/orb.yaml
+++ b/poetry/orb.yaml
@@ -54,7 +54,7 @@ jobs:
     description: >
       Run an arbitrary command within your poetry environment.
     executor: <<parameters.executor>>
-    parameters: &run-parameters
+    parameters:
       cmd:
         type: string
       configure_poetry:

--- a/poetry/orb.yaml
+++ b/poetry/orb.yaml
@@ -99,7 +99,7 @@ jobs:
           condition: <<parameters.extra>>
           steps:
             - run:
-                command: poetry install -n --no-ansi -E "<<parameters.extra>> "
+                command: poetry install -n --no-ansi -E "<<parameters.extra>>"
                 working_directory: <<parameters.cwd>>
       - unless:
           condition: <<parameters.extra>>

--- a/poetry/orb.yaml
+++ b/poetry/orb.yaml
@@ -91,7 +91,7 @@ jobs:
           command: poetry run <<parameters.cmd>>
           working_directory: <<parameters.cwd>>
 
-  run_with_extra:
+  run-with-extra:
     description: >
       Run an arbitrary command within your poetry
       environment with extras (-E flag)

--- a/poetry/orb.yaml
+++ b/poetry/orb.yaml
@@ -44,7 +44,7 @@ commands:
       - run: echo 'export PATH="/root/.local/bin:${PATH}"' >> ${BASH_ENV}
 
 jobs:
-  run:
+  run: &run
     description: >
       Run an arbitrary command within your poetry environment.
     docker:
@@ -90,6 +90,25 @@ jobs:
       - run:
           command: poetry run <<parameters.cmd>>
           working_directory: <<parameters.cwd>>
+
+  run_with_extra:
+    <<: *run
+    description: >
+      Run an arbitrary command within your poetry
+      environment with extras (-E flag)
+    parameters:
+      extra:
+        type: string
+    steps:
+      - install
+      - steps: <<parameters.configure_poetry>>
+      - run:
+          command: poetry install -n --no-ansi -E <<parameters.extra>>
+          working_directory: <<parameters.cwd>>
+      - run:
+          command: poetry run <<parameters.cmd>>
+          working_directory: <<parameters.cwd>>
+
 
   publish:
     description: >


### PR DESCRIPTION
## Summary
<!---
Summary of changes. Include any relevant context and complexities. Link any
relevant tickets / branches / other PRs / blockers / etc.
--->

I added a new job inside the poetry orb to run `poetry install` with an extra parameter (i.e. `-E` flag).  

### Checklist
<!---
See docs.talkiq-echelon.talkiq.com/static/docs/guides/pull-requests.html#guidelines

Feel free to add anything extra to the list if need be!
--->
- [ ] My comments/docstrings/type hints are clear
- [ ] I've written new tests or this change does not need them
- [ ] I've tested this manually
- [ ] The architecture diagrams have been updated, if need be
- [ ] I've included any special rollback strategies above
- [ ] Any relevant metrics/monitors/SLOs have been added or modified
- [ ] I've notified all relevant stakeholders of the change
- [ ] I've updated .github/CODEOWNERS, if relevant
