### PR TITLE
feat(notifier): enable slack notifs for deployments

### DIFF
--- a/notifier/orb.yaml
+++ b/notifier/orb.yaml
@@ -250,7 +250,7 @@ jobs:
           The name of the project.
         type: string
       user:
-        default: ${CIRCLE_USERNAME}
+        default: "@${CIRCLE_USERNAME}"
         description: |
           User responsible for this release.
         type: string


### PR DESCRIPTION
## Summary
So apparently the Slack "keywords that notify you" only *highlights* the
matching phrase if it does not start with an @ symbol. If we attach the
@ here, then any users who've added their Github username to their Slack
keywords list will correctly get a notification through this orb.

Note that adding the @ here makes this match the deployment failure notifier,
which has been pinging folks correctly.

### Checklist
- [x] My comments/docstrings/type hints are clear
- [x] I've written new tests or this change does not need them
- [x] I've tested this manually
- [x] The architecture diagrams have been updated, if need be
- [x] I've included any special rollback strategies above
- [x] Any relevant metrics/monitors/SLOs have been added or modified
- [x] I've notified all relevant stakeholders of the change
- [x] I've updated .github/CODEOWNERS, if relevant