### PR TITLE
feat(gcloud): cleaner command names

### DIFF
--- a/gcloud/orb.yaml
+++ b/gcloud/orb.yaml
@@ -123,10 +123,12 @@ commands:
           condition:
             equal: [ <<parameters.version>>, "latest" ]
           steps:
-            - run: |
-                if [ ! -d /root/google-cloud-sdk ]; then
-                  curl -sSL https://sdk.cloud.google.com | bash -s -- --disable-prompts
-                fi
+            - run:
+                name: install gcloud
+                command: |
+                  if [ ! -d /root/google-cloud-sdk ]; then
+                    curl -sSL https://sdk.cloud.google.com | bash -s -- --disable-prompts
+                  fi
       - when:
           condition:
             not:
@@ -137,27 +139,35 @@ commands:
             # The only difference here is in the sed commands:
             # * remove some unnecessary >10k line verbose logging, and
             # * download a specified version of gcloud
-            - run: |
-                if [ ! -d /root/google-cloud-sdk ]; then
-                  scratch="$(mktemp -d -t tmp.XXXXXXXXXX)"
-                  curl -sSLo "${scratch}/install.sh" https://dl.google.com/dl/cloudsdk/channels/rapid/install_google_cloud_sdk.bash
-                  sed -i 's/-zxvf/-zxf/' "${scratch}/install.sh"
-                  sed -i 's#^__SDK_URL_DIR=\(.*\)$#__SDK_URL_DIR=\1/downloads#' "${scratch}/install.sh"
-                  sed -i 's/^__SDK_TGZ.*$/__SDK_TGZ="google-cloud-sdk-<<parameters.version>>-linux-x86_64.tar.gz"/' "${scratch}/install.sh"
-                  bash "${scratch}/install.sh" --disable-prompts
-                fi
-      - run: |
-          if [ ! -f /usr/bin/gcloud ]; then
-            ln -s /root/google-cloud-sdk/bin/gcloud /usr/bin/gcloud
-          fi
-      - run: |
-          if [ ! -f /usr/bin/gsutil ]; then
-            ln -s /root/google-cloud-sdk/bin/gsutil /usr/bin/gsutil
-          fi
-      - run: |
-          if [ ! -f /usr/bin/docker-credential-gcloud ]; then
-            ln -s /root/google-cloud-sdk/bin/docker-credential-gcloud /usr/bin/docker-credential-gcloud
-          fi
+            - run:
+                name: install gcloud
+                command: |
+                  if [ ! -d /root/google-cloud-sdk ]; then
+                    scratch="$(mktemp -d -t tmp.XXXXXXXXXX)"
+                    curl -sSLo "${scratch}/install.sh" https://dl.google.com/dl/cloudsdk/channels/rapid/install_google_cloud_sdk.bash
+                    sed -i 's/-zxvf/-zxf/' "${scratch}/install.sh"
+                    sed -i 's#^__SDK_URL_DIR=\(.*\)$#__SDK_URL_DIR=\1/downloads#' "${scratch}/install.sh"
+                    sed -i 's/^__SDK_TGZ.*$/__SDK_TGZ="google-cloud-sdk-<<parameters.version>>-linux-x86_64.tar.gz"/' "${scratch}/install.sh"
+                    bash "${scratch}/install.sh" --disable-prompts
+                  fi
+      - run:
+          name: symlink gcloud
+          command: |
+            if [ ! -f /usr/bin/gcloud ]; then
+              ln -s /root/google-cloud-sdk/bin/gcloud /usr/bin/gcloud
+            fi
+      - run:
+          name: symlink gsutil
+          command: |
+            if [ ! -f /usr/bin/gsutil ]; then
+              ln -s /root/google-cloud-sdk/bin/gsutil /usr/bin/gsutil
+            fi
+      - run:
+          name: symlink docker-credential-gcloud
+          command: |
+            if [ ! -f /usr/bin/docker-credential-gcloud ]; then
+              ln -s /root/google-cloud-sdk/bin/docker-credential-gcloud /usr/bin/docker-credential-gcloud
+            fi
 
   patch-configmap-entry:
     description: >


### PR DESCRIPTION
## Summary
Give some human-readable names for complex commands that are
incomprehensible in the CI job output pages.

ie. this:
<img width="1078" alt="image" src="https://user-images.githubusercontent.com/3341822/188195840-916a9c71-5a89-4472-9f7d-11fa95efbb7f.png">
