### PR TITLE
fix(notifier): fix typo in executor name

### DIFF
--- a/notifier/orb.yaml
+++ b/notifier/orb.yaml
@@ -5,7 +5,7 @@ orbs:
   slack: circleci/slack@4
 
 executors:
-  alpine-stable:
+  alpine-latest:
     docker:
       - image: alpine:latest
     resource_class: small


### PR DESCRIPTION
## Summary
Fixup a typo which breaks the notifier orb.

### Checklist
- [x] My comments/docstrings/type hints are clear
- [x] I've written new tests or this change does not need them
- [x] I've tested this manually
- [x] The architecture diagrams have been updated, if need be
- [x] I've included any special rollback strategies above
- [x] Any relevant metrics/monitors/SLOs have been added or modified
- [x] I've notified all relevant stakeholders of the change
- [x] I've updated .github/CODEOWNERS, if relevant
