### PR TITLE
feat(linter): Add optional setup steps + ability to override pre-commit args

### DIFF
--- a/linter/orb.yaml
+++ b/linter/orb.yaml
@@ -28,6 +28,11 @@ commands:
         description: >
           Pre-commit package version.
         type: string
+      args:
+        default: --all-files --show-diff-on-failure
+        description: >
+          Pre-commit parameters
+        type: string
     steps:
       - when:
           condition:
@@ -48,7 +53,7 @@ commands:
           key: cache-pre-commit-<<parameters.cache_prefix>>-{{ checksum "<<parameters.config_file>>" }}
           paths:
             - ~/.cache/pre-commit
-      - run: pre-commit run --all-files --show-diff-on-failure -c <<parameters.config_file>>
+      - run: pre-commit run <<parameters.args>> -c <<parameters.config_file>>
 
 jobs:
   pre-commit:
@@ -80,8 +85,14 @@ jobs:
         description: >
           Pre-commit package version.
         type: string
+      args:
+        default: --all-files --show-diff-on-failure
+        description: >
+          Pre-commit parameters
+        type: string
     steps:
       - pre-commit:
           cache_prefix: <<parameters.cache_prefix>>
           config_file: <<parameters.config_file>>
           version: <<parameters.pre_commit_version>>
+          args: <<parameters.args>>


### PR DESCRIPTION
## Summary
- Making it possible to change args passed to `pre-commit` (default stays the same, `--all-files --show-diff-on-failure`)
- Add a `setup` parameter that can be used to provide steps ran before the `pre-commit` command runs

### Checklist
<!---
See docs.talkiq-echelon.talkiq.com/static/docs/guides/pull-requests.html#guidelines

Feel free to add anything extra to the list if need be!
--->
- [x] My comments/docstrings/type hints are clear
- [x] I've written new tests or this change does not need them
- [ ] I've tested this manually
- [ ] The architecture diagrams have been updated, if need be
- [ ] I've included any special rollback strategies above
- [ ] Any relevant metrics/monitors/SLOs have been added or modified
- [ ] I've notified all relevant stakeholders of the change
- [ ] I've updated .github/CODEOWNERS, if relevant
