### PR TITLE
feat(gcloud): add optional flags to gcf deploy

### DIFF
--- a/gcloud/orb.yaml
+++ b/gcloud/orb.yaml
@@ -325,12 +325,6 @@ jobs:
         description: >
           Name of the cloud function being deployed.
         type: string
-      memory:
-        default: ''
-        description: >
-          Limit on the amount of memory the function can use. Allowed values
-          are: 128MB, 256MB, 512MB, 1024MB, and 2048MB.
-        type: string
       packagename:
         description: >
           Name of the package to be deployed to this cloud function.
@@ -359,18 +353,11 @@ jobs:
             cp "./<<parameters.packagename>>/mains/<<parameters.funcname>>.py" main.py
             cp -R "./<<parameters.packagename>>" main.py requirements.txt /tmp/build
           working_directory: functions
-      - when:
-          condition: <<parameters.memory>>
-          steps:
-            - run: |
-                gcloud functions deploy <<parameters.funcname>> --memory=<<parameters.memory>> \
-                  --source="/tmp/build" <<parameters.flags>>
-      - unless:
-          condition: <<parameters.memory>>
-          steps:
-            - run: |
-                gcloud functions deploy <<parameters.funcname>> --source="/tmp/build" \
-                  <<parameters.flags>>
+      - run:
+          name: deploy cloud function
+          command: |
+            gcloud functions deploy <<parameters.funcname>> --source="/tmp/build" \
+              <<parameters.flags>>
 
   deploy-cloud-run:
     description: >

--- a/gcloud/orb.yaml
+++ b/gcloud/orb.yaml
@@ -316,6 +316,11 @@ jobs:
           `https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-executors`.
           Defaults to a small google/cloud-sdk:alpine docker image.
         type: executor
+      flags:
+        description: >
+          Additional flags to pass to the `gcloud functions deploy` command.
+        default: ''
+        type: string
       funcname:
         description: >
           Name of the cloud function being deployed.
@@ -359,12 +364,13 @@ jobs:
           steps:
             - run: |
                 gcloud functions deploy <<parameters.funcname>> --memory=<<parameters.memory>> \
-                  --source="/tmp/build"
+                  --source="/tmp/build" <<parameters.flags>>
       - unless:
           condition: <<parameters.memory>>
           steps:
             - run: |
-                gcloud functions deploy <<parameters.funcname>> --source="/tmp/build"
+                gcloud functions deploy <<parameters.funcname>> --source="/tmp/build" \
+                  <<parameters.flags>>
 
   deploy-cloud-run:
     description: >


### PR DESCRIPTION
## Summary
<!---
Summary of changes. Include any relevant context and complexities. Link any
relevant tickets / branches / other PRs / blockers / etc.
--->

Expose additional `flags` for `gcloud/deploy-cloud-function` and remove the `memory` parameter, which will result in a major version bump on the `gcloud` orb. For more details, please see https://github.com/talkiq/terraform/pull/1867.

### Checklist
<!---
See docs.talkiq-echelon.talkiq.com/static/docs/guides/pull-requests.html#guidelines

Feel free to add anything extra to the list if need be!
--->
- [x] My comments/docstrings/type hints are clear
- [x] I've written new tests or this change does not need them
- [x] I've tested this manually
- [x] The architecture diagrams have been updated, if need be
- [x] I've included any special rollback strategies above
- [x] Any relevant metrics/monitors/SLOs have been added or modified
- [x] I've notified all relevant stakeholders of the change
- [x] I've updated .github/CODEOWNERS, if relevant
