### PR TITLE
Fix "unknown option was passed in to libcurl"

### DIFF
--- a/gcloud/orb.yaml
+++ b/gcloud/orb.yaml
@@ -122,7 +122,7 @@ commands:
           name: install dependencies
           command: |
             if which apk >/dev/null; then
-              apk add --no-cache --no-progress bash curl python3
+              apk add --no-cache --no-progress bash curl curl-dev python3
             elif which apt-get >/dev/null; then
               apt-get update -qy
               apt-get install -qy bash curl python

--- a/gcloud/orb.yaml
+++ b/gcloud/orb.yaml
@@ -122,7 +122,8 @@ commands:
           name: install dependencies
           command: |
             if which apk >/dev/null; then
-              apk add --no-cache --no-progress bash curl curl-dev python3
+              apk upgrade
+              apk add --update-cache --no-progress bash curl python3
             elif which apt-get >/dev/null; then
               apt-get update -qy
               apt-get install -qy bash curl python


### PR DESCRIPTION
## Summary

It seems that on certain versions of linux `apk add curl` is installing a mismatched version of curl and libcurl:

```
82d3cd0591f4:~/project# curl -o foo.bar google.com
curl: (48) An unknown option was passed in to libcurl
```

Eg:

```
a796ad7cecbc:~/project# curl -V
curl 7.87.0 (x86_64-alpine-linux-musl) libcurl/7.86.0 OpenSSL/3.0.7 zlib/1.2.13 brotli/1.0.9 nghttp2/1.51.0
Release-Date: 2022-12-21
Protocols: dict file ftp ftps gopher gophers http https imap imaps mqtt pop3 pop3s rtsp smb smbs smtp smtps telnet tftp ws wss
Features: alt-svc AsynchDNS brotli HSTS HTTP2 HTTPS-proxy IPv6 Largefile libz NTLM NTLM_WB SSL threadsafe TLS-SRP UnixSockets
WARNING: curl and libcurl versions do not match. Functionality may be affected.
```

and two libcurls get installed side by side:

```
a796ad7cecbc:~/project# find /usr -name "libcurl*"
/usr/lib/libcurl.so.4
/usr/lib/libcurl.so.4.8.0
```

Installation of `curl-dev` pulls in the correct version.

@TheKevJames: For some reason, alpine is shipping with an outdated header but not curl itself, so we need to either upgrade that header or install the matching version of curl with a version tag.