### PR TITLE
Skips curl installation when already present

### DIFF
--- a/notifier/orb.yaml
+++ b/notifier/orb.yaml
@@ -29,7 +29,9 @@ commands:
       - run:
           name: install curl
           command: |
-            if which apk >/dev/null; then
+            if which curl >/dev/null; then
+              exit 0
+            elif which apk >/dev/null; then
               apk add --no-cache --no-progress curl curl-dev
             elif which apt-get >/dev/null; then
               apt-get update -qy


### PR DESCRIPTION
## Summary
<!---
Summary of changes. Include any relevant context and complexities. Link any
relevant tickets / branches / other PRs / blockers / etc.
--->
Issues can arise where `apt-get update` fails and then the whole process of trying to notify slack results in failed CI jobs.  Allow the chance for users to install curl on their own and skip package management of any kind.

### Checklist
<!---
See docs.talkiq-echelon.talkiq.com/static/docs/guides/pull-requests.html#guidelines

Feel free to add anything extra to the list if need be!
--->
- [x] My comments/docstrings/type hints are clear
- [x] I've written new tests or this change does not need them
- [x] I've tested this manually
- [x] The architecture diagrams have been updated, if need be
- [x] I've included any special rollback strategies above
- [x] Any relevant metrics/monitors/SLOs have been added or modified
- [x] I've notified all relevant stakeholders of the change
- [x] I've updated .github/CODEOWNERS, if relevant
