### PR TITLE
fix(linter): force py3 usage for pre-commit

### DIFF
--- a/linter/orb.yaml
+++ b/linter/orb.yaml
@@ -38,12 +38,12 @@ commands:
           condition:
             equal: [latest, <<parameters.version>>]
           steps:
-            - run: python -m pip install --progress-bar=off pre-commit
+            - run: python3 -m pip install --progress-bar=off pre-commit
       - unless:
           condition:
             equal: [latest, <<parameters.version>>]
           steps:
-            - run: python -m pip install --progress-bar=off pre-commit==<<parameters.version>>
+            - run: python3 -m pip install --progress-bar=off pre-commit==<<parameters.version>>
       - checkout
       - restore_cache:
           keys:


### PR DESCRIPTION
## Summary
pre-commit only support py3, we should ensure we're running via the
correct python in cases where python2 is also installed, the symlink
doesn't exist, or the symlink points to py2.

### Custom Checklist Items
<!---
Anything extra for this PR not covered in the standard checklist below. For
simple PRs, leave this empty, but otherwise this is a good place to list
dependencies, extra steps before this can be merged, etc.
--->

### Standard Checklist
<!---
Have you ensured your comments/docstrings/type hints are clear? For example,
are you using ``typing.Any`` and need to clarify? Are you using a ``str`` when
an ``enum.Enum`` would fit better? Would it be clear to clients what to pass
in, return from, and catch when working with your methods?
--->
- [x] My comments/docstrings/type hints are clear
<!---
Have you written tests? Unit vs generative vs integration vs e2e as need be!

Consider: does this change require testing on staging, or do the automated
tests capture 100% of all issues?
--->
- [x] I've written new tests or this change does not need them
<!---
Have you manually tested? Run locally, smoke test on staging, etc!
--->
- [x] I've tested this manually
<!---
Do we need to update an [architecture diagram](https://docs.talkiq-echelon.talkiq.com/static/docs/arch/index.html)?
--->
- [x] The architecture diagrams have been updated, if need be
<!---
If there are any other related changes which should be reviewed together, or
other work whih must be deployed first, have you linked to them and described
the interaction?
--->
- [x] Any external changes/dependencies are linked and described
<!---
Is there a non-default rollback strategy we'd need to consider (eg. is ``git
revert`` enough or would we need to, say, also flush a task queue)?
--->
- [x] I've included any special rollback strategies above
<!---
Are there any new metrics/monitors/alerts we need to add? How does this affect
our SLO tracking?
--->
- [x] Any relevant metrics/monitors/SLOs have been added or modified
<!---
Are there any changes to assumptions other members of the team might have? Is
this a new tool/feature/etc which might benefit them? To whom should we
broadcast news of this change?
--->
- [x] I've notified all relevant stakeholders of the change
<!---
Have you removed a bunch of code which might have previously added codeowners?
Added something entirely new? Made significant enough changes to warrant your
eyes on future PRs in this area in the near future?
--->
- [x] I've updated .github/CODEOWNERS, if relevant
