### PR TITLE
chore(poetry): disable ansi output

### DIFF
--- a/poetry/orb.yaml
+++ b/poetry/orb.yaml
@@ -103,7 +103,7 @@ jobs:
       - steps: <<parameters.configure_poetry>>
       - checkout
       - run:
-          command: poetry install -n <<parameters.install_flags>>
+          command: poetry install -n --no-ansi <<parameters.install_flags>>
           working_directory: <<parameters.cwd>>
       - steps: <<parameters.commands>>
 


### PR DESCRIPTION
Ansi output leads to duplication of log lines in our CI output, and
seems to contribute to the whole "need to pin to poetry 1.2.2 for older
pythons" problem.

Disabling it globally should allow us to avoid any manual downstream
pinning.
