### PR TITLE
feat(poetry): use sudo to install curl if running as user

### DIFF
--- a/poetry/orb.yaml
+++ b/poetry/orb.yaml
@@ -26,16 +26,24 @@ commands:
         type: string
     steps:
       - run:
-          name: install curl
+          name: Install curl
           command: |
-            if which apk >/dev/null; then
-              apk add --no-cache --no-progress curl
-            elif which apt-get >/dev/null; then
-              apt-get update -qy
-              apt-get install -qy curl
+            if cat /etc/issue | grep "Alpine" >/dev/null 2>&1; then
+              if [ "$ID" = 0 ]; then export SUDO=""; else export SUDO="sudo"; fi
             else
-              echo >&2 "ERROR: could not find supported package manager"
-              exit 1
+              if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
+            fi
+            echo "export SUDO=$SUDO" >> ${BASH_ENV}
+            if [ ! "$(command -v curl)" ]; then
+              if which apk >/dev/null; then
+                $SUDO apk add --no-cache --no-progress curl
+              elif which apt-get >/dev/null; then
+                $SUDO apt-get update -qy
+                $SUDO apt-get install -qy curl
+              else
+                echo >&2 "ERROR: could not find supported package manager"
+                exit 1
+              fi
             fi
       - unless:
           condition:


### PR DESCRIPTION
## Summary
If the UID is not 0 (root), uses sudo to install curl. Also checking if curl is already installed before trying to install it.

### Standard Checklist
<!---
Have you ensured your comments/docstrings/type hints are clear? For example,
are you using ``typing.Any`` and need to clarify? Are you using a ``str`` when
an ``enum.Enum`` would fit better? Would it be clear to clients what to pass
in, return from, and catch when working with your methods?
--->
- [ ] My comments/docstrings/type hints are clear
<!---
Have you written tests? Unit vs generative vs integration vs e2e as need be!

Consider: does this change require testing on staging, or do the automated
tests capture 100% of all issues?
--->
- [ ] I've written new tests or this change does not need them
<!---
Have you manually tested? Run locally, smoke test on staging, etc!
--->
- [ ] I've tested this manually
<!---
Do we need to update an [architecture diagram](https://docs.talkiq-echelon.talkiq.com/static/docs/arch/index.html)?
--->
- [ ] The architecture diagrams have been updated, if need be
<!---
If there are any other related changes which should be reviewed together, or
other work whih must be deployed first, have you linked to them and described
the interaction?
--->
- [ ] Any external changes/dependencies are linked and described
<!---
Is there a non-default rollback strategy we'd need to consider (eg. is ``git
revert`` enough or would we need to, say, also flush a task queue)?
--->
- [ ] I've included any special rollback strategies above
<!---
Are there any new metrics/monitors/alerts we need to add? How does this affect
our SLO tracking?
--->
- [ ] Any relevant metrics/monitors/SLOs have been added or modified
<!---
Are there any changes to assumptions other members of the team might have? Is
this a new tool/feature/etc which might benefit them? To whom should we
broadcast news of this change?
--->
- [ ] I've notified all relevant stakeholders of the change
<!---
Have you removed a bunch of code which might have previously added codeowners?
Added something entirely new? Made significant enough changes to warrant your
eyes on future PRs in this area in the near future?
--->
- [ ] I've updated .github/CODEOWNERS, if relevant
