### PR TITLE
fix(linter): support PEP668

### DIFF
--- a/linter/orb.yaml
+++ b/linter/orb.yaml
@@ -10,7 +10,8 @@ executors:
 commands:
   pre-commit:
     description: |
-      Runs pre-commit hooks against the current repo. Must be run in an executor with git, python, pip.
+      Runs pre-commit hooks against the current repo. Must be run in an
+      executor with pre-commit installed.
     parameters:
       cache_prefix:
         default: ''
@@ -23,27 +24,12 @@ commands:
         description: >
           Optional alternate config file.
         type: string
-      version:
-        default: latest
-        description: >
-          Pre-commit package version.
-        type: string
       args:
         default: --all-files --show-diff-on-failure
         description: >
           Pre-commit parameters
         type: string
     steps:
-      - when:
-          condition:
-            equal: [latest, <<parameters.version>>]
-          steps:
-            - run: python3 -m pip install --progress-bar=off pre-commit
-      - unless:
-          condition:
-            equal: [latest, <<parameters.version>>]
-          steps:
-            - run: python3 -m pip install --progress-bar=off pre-commit==<<parameters.version>>
       - checkout
       - restore_cache:
           keys:
@@ -61,6 +47,11 @@ jobs:
       Runs pre-commit hooks against the current repo.
     executor: <<parameters.executor>>
     parameters:
+      args:
+        default: --all-files --show-diff-on-failure
+        description: >
+          Pre-commit parameters
+        type: string
       cache_prefix:
         default: ''
         description: >
@@ -75,24 +66,35 @@ jobs:
       executor:
         default: python-latest
         description: >
-          Executor for the job. Must have a working Python version installed.
-          To use your own custom executor, see
+          Executor for the job. Must have python3 installed and support
+          ${BASH_ENV} updates. To use your own custom executor, see
           `https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-executors`.
+          For alpine support, see
+          `https://circleci.com/docs/env-vars#alpine-linux`.
           Defaults to a small python:latest docker image.
         type: executor
-      pre_commit_version:
+      version:
         default: latest
         description: >
           Pre-commit package version.
         type: string
-      args:
-        default: --all-files --show-diff-on-failure
-        description: >
-          Pre-commit parameters
-        type: string
     steps:
+      - run:
+          name: create and activate venv
+          command: |
+            python3 -m venv /venv
+            echo "source /venv/bin/activate" >> ${BASH_ENV}
+      - when:
+          condition:
+            equal: [<<parameters.version>>, latest]
+          steps:
+            - run: python3 -m pip install --progress-bar=off pre-commit
+      - unless:
+          condition:
+            equal: [<<parameters.version>>, latest]
+          steps:
+            - run: python3 -m pip install --progress-bar=off "pre-commit==<<parameters.version>>"
       - pre-commit:
           cache_prefix: <<parameters.cache_prefix>>
           config_file: <<parameters.config_file>>
-          version: <<parameters.pre_commit_version>>
           args: <<parameters.args>>


### PR DESCRIPTION
## Summary
<!---
Summary of changes. Include any relevant context and complexities. Link any
relevant tickets / branches / other PRs / blockers / etc.
--->
BREAKING CHANGE!

With PEP668, global package installations are no longer possible, even
in something like docker where an additional layer of virtualenvs is
entirely meaningless. As such, we need to overhaul this orb to install
pre-commit in a venv, which in turn means alpine-based executors need
shell/env overrides and a single command for "install and run
pre-commit" is not really doable anymore: there are too many different
possible base images to account for them all.

Definitely open to any suggestions, especially on:
* ways to make this less breaking
* any new convenience commands/jobs/etc which would help out here

### Standard Checklist
<!---
Have you ensured your comments/docstrings/type hints are clear? For example,
are you using ``typing.Any`` and need to clarify? Are you using a ``str`` when
an ``enum.Enum`` would fit better? Would it be clear to clients what to pass
in, return from, and catch when working with your methods?
--->
- [x] My comments/docstrings/type hints are clear
<!---
Have you written tests? Unit vs generative vs integration vs e2e as need be!

Consider: does this change require testing on staging, or do the automated
tests capture 100% of all issues?
--->
- [x] I've written new tests or this change does not need them
<!---
Have you manually tested? Run locally, smoke test on staging, etc!
--->
- [x] I've tested this manually
<!---
Do we need to update an [architecture diagram](https://docs.talkiq-echelon.talkiq.com/static/docs/arch/index.html)?
--->
- [x] The architecture diagrams have been updated, if need be
<!---
If there are any other related changes which should be reviewed together, or
other work which must be deployed first, have you linked to them and described
the interaction?
--->
- [x] Any external changes/dependencies are linked and described
<!---
Is there a non-default rollback strategy we'd need to consider (eg. is ``git
revert`` enough or would we need to, say, also flush a task queue)?
--->
- [x] I've included any special rollback strategies above
<!---
Are there any new metrics/monitors/alerts we need to add? How does this affect
our SLO tracking?
--->
- [x] Any relevant metrics/monitors/SLOs have been added or modified
<!---
Are there any changes to assumptions other members of the team might have? Is
this a new tool/feature/etc which might benefit them? To whom should we
broadcast news of this change?
--->
- [x] I've notified all relevant stakeholders of the change
<!---
Have you removed a bunch of code which might have previously added codeowners?
Added something entirely new? Made significant enough changes to warrant your
eyes on future PRs in this area in the near future?
--->
- [x] I've updated .github/CODEOWNERS, if relevant
