### PR TITLE
docs: clarify usage of dev versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,13 +36,31 @@ Latest Versions
 Development
 -----------
 
-To release a new version of any orb, force push the tag corresponding to that
-orb and the given release type: ``$ORBNAME-{major,minor,patch}``. Please be
-sure to do this only off of commits on master; any other commits on any other
-branches will release `dev versions`_, which should be enough for testing
-pre-merge.
+Every commit will build dev versions of all our orbs, which can be used within
+any other ``talkiq`` repos for up to 30 days. Check the output of the
+``publish-dev-orbs-${ORBNAME}`` job to see the version number; it should look
+something like this: ``talkiq/poetry@dev:628e28f``. This version string string
+can be used directly, eg. by applying the following change in another repo, for
+the purpose of testing:
 
-Note that the ``$ORBNAME``, for example, ``"talkiq/linter"``.
+.. code-block:: diff
+
+    - poetry: talkiq/poetry@4
+    + poetry: talkiq/poetry@dev:628e28f
+
+Once your PR has been merged, you can release a new version of any orb by force
+push the tag corresponding to that orb and the given release type:
+``${ORBNAME}-{major,minor,patch}``. For example:
+
+.. code-block:: bash
+
+    git tag -f talkiq/linter-patch && git push -f origin talkiq/linter-patch
+
+Please be sure to do this only off of commits on master! The `dev versions`_
+described above should be enough for testing your changes pre-merge.
+
+Note that the ``${ORBNAME}``, for example, is namespaced with ``talkiq`` and so
+should be formatted as, eg. ``"talkiq/linter"``.
 
 .. |docker| image:: https://badges.circleci.com/orbs/talkiq/docker.svg
     :alt: Latest Version


### PR DESCRIPTION
## Summary
<!---
Summary of changes. Include any relevant context and complexities. Link any
relevant tickets / branches / other PRs / blockers / etc.
--->
Clarify how to work with dev versions in this repo.

### Standard Checklist
<!---
Have you ensured your comments/docstrings/type hints are clear? For example,
are you using ``typing.Any`` and need to clarify? Are you using a ``str`` when
an ``enum.Enum`` would fit better? Would it be clear to clients what to pass
in, return from, and catch when working with your methods?
--->
- [x] My comments/docstrings/type hints are clear
<!---
Have you written tests? Unit vs generative vs integration vs e2e as need be!

Consider: does this change require testing on staging, or do the automated
tests capture 100% of all issues?
--->
- [x] I've written new tests or this change does not need them
<!---
Have you manually tested? Run locally, smoke test on staging, etc!
--->
- [x] I've tested this manually
<!---
Do we need to update an [architecture diagram](https://docs.talkiq-echelon.talkiq.com/static/docs/arch/index.html)?
--->
- [x] The architecture diagrams have been updated, if need be
<!---
If there are any other related changes which should be reviewed together, or
other work which must be deployed first, have you linked to them and described
the interaction?
--->
- [x] Any external changes/dependencies are linked and described
<!---
Is there a non-default rollback strategy we'd need to consider (eg. is ``git
revert`` enough or would we need to, say, also flush a task queue)?
--->
- [x] I've included any special rollback strategies above
<!---
Are there any new metrics/monitors/alerts we need to add? How does this affect
our SLO tracking?
--->
- [x] Any relevant metrics/monitors/SLOs have been added or modified
<!---
Are there any changes to assumptions other members of the team might have? Is
this a new tool/feature/etc which might benefit them? To whom should we
broadcast news of this change?
--->
- [x] I've notified all relevant stakeholders of the change
<!---
Have you removed a bunch of code which might have previously added codeowners?
Added something entirely new? Made significant enough changes to warrant your
eyes on future PRs in this area in the near future?
--->
- [x] I've updated .github/CODEOWNERS, if relevant
