### PR TITLE
fix(gcloud): support deploy-gke for first deploy to new cluster

### DIFF
--- a/gcloud/orb.yaml
+++ b/gcloud/orb.yaml
@@ -437,14 +437,14 @@ jobs:
                   # manifest, parse out the tag as the last (3rd) chunk of img, and
                   # further split the tag to retrieve the rightmost chunk: the commit
                   # hash.
-                  kubectl get deployments -l <<parameters.version_selector>> -oyaml | awk '/image: / {split($0,img,":"); len=split(img[3],tag,"-"); print tag[len]}' | tail -n1 > /metadata/prev_version/<<parameters.deployment>>/<<parameters.cluster>>/<<parameters.zone>>
+                  kubectl get deployments -l <<parameters.version_selector>> --ignore-not-found=true -oyaml | awk '/image: / {split($0,img,":"); len=split(img[3],tag,"-"); print tag[len]}' | tail -n1 > /metadata/prev_version/<<parameters.deployment>>/<<parameters.cluster>>/<<parameters.zone>>
       - unless:
           condition: <<parameters.version_selector>>
           steps:
             - run:
                 name: store previous version
                 command: |
-                  kubectl get deployments <<parameters.deployment>> -oyaml | awk '/image: / {split($0,img,":"); len=split(img[3],tag,"-"); print tag[len]}' | tail -n1 > /metadata/prev_version/<<parameters.deployment>>/<<parameters.cluster>>/<<parameters.zone>>
+                  kubectl get deployments <<parameters.deployment>> --ignore-not-found=true -oyaml | awk '/image: / {split($0,img,":"); len=split(img[3],tag,"-"); print tag[len]}' | tail -n1 > /metadata/prev_version/<<parameters.deployment>>/<<parameters.cluster>>/<<parameters.zone>>
       - when:
           condition: <<parameters.prune_selector>>
           steps:


### PR DESCRIPTION
## Summary
<!---
Summary of changes. Include any relevant context and complexities. Link any
relevant tickets / branches / other PRs / blockers / etc.
--->
Ensures we're allowed to deploy the first revision of a deployment to an empty
cluster.

### Standard Checklist
<!---
Have you ensured your comments/docstrings/type hints are clear? For example,
are you using ``typing.Any`` and need to clarify? Are you using a ``str`` when
an ``enum.Enum`` would fit better? Would it be clear to clients what to pass
in, return from, and catch when working with your methods?
--->
- [x] My comments/docstrings/type hints are clear
<!---
Have you written tests? Unit vs generative vs integration vs e2e as need be!

Consider: does this change require testing on staging, or do the automated
tests capture 100% of all issues?
--->
- [x] I've written new tests or this change does not need them
<!---
Have you manually tested? Run locally, smoke test on staging, etc!
--->
- [ ] I've tested this manually
<!---
Do we need to update an [architecture diagram](https://docs.talkiq-echelon.talkiq.com/static/docs/arch/index.html)?
--->
- [x] The architecture diagrams have been updated, if need be
<!---
If there are any other related changes which should be reviewed together, or
other work which must be deployed first, have you linked to them and described
the interaction?
--->
- [x] Any external changes/dependencies are linked and described
<!---
Is there a non-default rollback strategy we'd need to consider (eg. is ``git
revert`` enough or would we need to, say, also flush a task queue)?
--->
- [x] I've included any special rollback strategies above
<!---
Are there any new metrics/monitors/alerts we need to add? How does this affect
our SLO tracking?
--->
- [x] Any relevant metrics/monitors/SLOs have been added or modified
<!---
Are there any changes to assumptions other members of the team might have? Is
this a new tool/feature/etc which might benefit them? To whom should we
broadcast news of this change?
--->
- [x] I've notified all relevant stakeholders of the change
<!---
Have you removed a bunch of code which might have previously added codeowners?
Added something entirely new? Made significant enough changes to warrant your
eyes on future PRs in this area in the near future?
--->
- [x] I've updated .github/CODEOWNERS, if relevant
