### PR TITLE
chore(poetry-publish): Allow users to specify timeout for poetry build

### DIFF
--- a/poetry/orb.yaml
+++ b/poetry/orb.yaml
@@ -118,6 +118,12 @@ jobs:
           workflows with complicated build processes.
         type: boolean
         default: true
+      build_timeout:
+        description: >
+          Sets the timeout value for 'poetry build' step. Useful for
+          workflows with longer build times.
+        type: string
+        default: 10m
       cwd:
         default: '.'
         description: >
@@ -173,6 +179,7 @@ jobs:
           steps:
             - run:
                 command: poetry build
+                no_output_timeout: <<parameters.build_timeout>>
                 working_directory: <<parameters.cwd>>
       - when:
           condition: << parameters.repository_url >>


### PR DESCRIPTION
## Summary
Allows users to specify the build timeout for processes that take longer than CircleCI's default of 10 minutes.

### Custom Checklist Items
<!---
Anything extra for this PR not covered in the standard checklist below. For
simple PRs, leave this empty, but otherwise this is a good place to list
dependencies, extra steps before this can be merged, etc.
--->

### Standard Checklist
<!---
Have you ensured your comments/docstrings/type hints are clear? For example,
are you using ``typing.Any`` and need to clarify? Are you using a ``str`` when
an ``enum.Enum`` would fit better? Would it be clear to clients what to pass
in, return from, and catch when working with your methods?
--->
- [ ] My comments/docstrings/type hints are clear
<!---
Have you written tests? Unit vs generative vs integration vs e2e as need be!

Consider: does this change require testing on staging, or do the automated
tests capture 100% of all issues?
--->
- [ ] I've written new tests or this change does not need them
<!---
Have you manually tested? Run locally, smoke test on staging, etc!
--->
- [ ] I've tested this manually
<!---
Do we need to update an [architecture diagram](https://docs.talkiq-echelon.talkiq.com/static/docs/arch/index.html)?
--->
- [ ] The architecture diagrams have been updated, if need be
<!---
If there are any other related changes which should be reviewed together, or
other work which must be deployed first, have you linked to them and described
the interaction?
--->
- [ ] Any external changes/dependencies are linked and described
<!---
Is there a non-default rollback strategy we'd need to consider (eg. is ``git
revert`` enough or would we need to, say, also flush a task queue)?
--->
- [ ] I've included any special rollback strategies above
<!---
Are there any new metrics/monitors/alerts we need to add? How does this affect
our SLO tracking?
--->
- [ ] Any relevant metrics/monitors/SLOs have been added or modified
<!---
Are there any changes to assumptions other members of the team might have? Is
this a new tool/feature/etc which might benefit them? To whom should we
broadcast news of this change?
--->
- [ ] I've notified all relevant stakeholders of the change
<!---
Have you removed a bunch of code which might have previously added codeowners?
Added something entirely new? Made significant enough changes to warrant your
eyes on future PRs in this area in the near future?
--->
- [ ] I've updated .github/CODEOWNERS, if relevant
